### PR TITLE
allow custom namespace for metrics resources

### DIFF
--- a/demo/kserve/Kserve.md
+++ b/demo/kserve/Kserve.md
@@ -118,19 +118,18 @@ data:
 ~~~
 ### Adding resources to configure monitoring
 
-*Resources are created assuming the inferenceservice is deployed in `kserve-demo`. Change files accordingly if the inferenceservice namespace is different*
 
 ```
-oc apply -f ./custom-manifests/metrics/networkpolicy-uwm.yaml
+oc apply -f ./custom-manifests/metrics/networkpolicy-uwm.yaml -n ${TEST_NS}
 ```
 Edit the `peerauthentication-caikit-metrics` file to apply the appropriate `matchLabel` according to your `serving.knative.dev/service` label
 
 ```
-oc apply -f ./custom-manifests/metrics/peerauthentication-caikit-metrics.yaml
+oc apply -f ./custom-manifests/metrics/peerauthentication-caikit-metrics.yaml -n ${TEST_NS}
 ```
 ```
-oc apply -f ./custom-manifests/metrics/caikit-metrics-service.yaml
-oc apply -f ./custom-manifests/metrics/caikit-metrics-servicemonitor.yaml
+oc apply -f ./custom-manifests/metrics/caikit-metrics-service.yaml -n ${TEST_NS}
+oc apply -f ./custom-manifests/metrics/caikit-metrics-servicemonitor.yaml -n ${TEST_NS}
 ```
 
 ## Deploy Minio for example LLM model

--- a/demo/kserve/custom-manifests/metrics/caikit-metrics-service.yaml
+++ b/demo/kserve/custom-manifests/metrics/caikit-metrics-service.yaml
@@ -2,7 +2,6 @@ kind: Service
 apiVersion: v1
 metadata:
   name: caikit-example-isvc-predictor-default-sm
-  namespace: kserve-demo
   labels:
     name: caikit-example-isvc-predictor-default-sm
 spec:

--- a/demo/kserve/custom-manifests/metrics/caikit-metrics-servicemonitor.yaml
+++ b/demo/kserve/custom-manifests/metrics/caikit-metrics-servicemonitor.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: caikit-example-isvc-predictor-default-sm
-  namespace: kserve-demo
 spec:
   endpoints:
     - port: caikit-metrics

--- a/demo/kserve/custom-manifests/metrics/peerauthentication-caikit-metrics.yaml
+++ b/demo/kserve/custom-manifests/metrics/peerauthentication-caikit-metrics.yaml
@@ -2,7 +2,6 @@ apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
   name: caikit-metrics
-  namespace: kserve-demo
 spec:
   mtls:
     mode: STRICT


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
remove hardcoded namespaces from metrics relates resources and apply `-n ${TEST_NS}` according to #24 
