### PR TITLE
Add missing NS flags and minor changes to the kserve demo

### DIFF
--- a/demo/kserve/Kserve.md
+++ b/demo/kserve/Kserve.md
@@ -156,7 +156,7 @@ If you have installed prerequisites(servicemesh,serverless,kserve and minio), yo
 ~~~
 export TEST_NS=kserve-demo
 oc new-project ${TEST_NS}
-sed "s/<test_ns>/$TEST_NS/g" custom-manifests/service-mesh/smmr-test-ns.yaml | tee ./smmr-current.yaml | oc -n istio-system apply -f -
+oc patch smmr/default -n istio-system --type='json' -p="[{'op': 'add', 'path': '/spec/members/-', 'value': \"$TEST_NS\"}]"
 sed "s/<test_ns>/$TEST_NS/g" custom-manifests/service-mesh/peer-authentication-test-ns.yaml | tee ./peer-authentication-test-ns-current.yaml | oc apply -f -
 # we need this because of https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/serverless/serving#serverless-domain-mapping-custom-tls-cert_domain-mapping-custom-tls-cert
 ~~~

--- a/demo/kserve/Kserve.md
+++ b/demo/kserve/Kserve.md
@@ -136,7 +136,7 @@ oc apply -f ./custom-manifests/metrics/caikit-metrics-servicemonitor.yaml -n ${T
 
 ## Deploy Minio for example LLM model
 
-You have your model in another S3-like object storage (e.g., AWS S3), you can skip this step.
+If you have your model in another S3-like object storage (e.g., AWS S3), you can skip this step.
 ~~~
 ACCESS_KEY_ID=THEACCESSKEY
 SECRET_ACCESS_KEY=$(openssl rand -hex 32)

--- a/demo/kserve/Kserve.md
+++ b/demo/kserve/Kserve.md
@@ -177,7 +177,7 @@ oc apply -f ./custom-manifests/caikit/caikit-isvc.yaml -n ${TEST_NS}
 
 ### gRPC Test
 ~~~
-export KSVC_HOSTNAME=$(oc get ksvc caikit-example-isvc-predictor -o jsonpath='{.status.url}' | cut -d'/' -f3)
+export KSVC_HOSTNAME=$(oc get ksvc caikit-example-isvc-predictor -n ${TEST_NS} -o jsonpath='{.status.url}' | cut -d'/' -f3)
 grpcurl -insecure -d '{"text": "At what temperature does liquid Nitrogen boil?"}' -H "mm-model-id: flan-t5-small-caikit" ${KSVC_HOSTNAME}:443 caikit.runtime.Nlp.NlpService/TextGenerationTaskPredict
 ~~~
 

--- a/demo/kserve/Kserve.md
+++ b/demo/kserve/Kserve.md
@@ -119,8 +119,6 @@ data:
       retention: 15d #Change as needed
 ~~~
 ### Adding resources to configure monitoring
-
-
 ```
 oc apply -f ./custom-manifests/metrics/networkpolicy-uwm.yaml -n ${TEST_NS}
 ```
@@ -164,7 +162,11 @@ sed "s/<test_ns>/$TEST_NS/g" custom-manifests/service-mesh/peer-authentication-t
 ~~~
 
 ### Create Caikit ServingRuntime
-
+Before running the next line: if you are going to serve the model using CPU and not GPU, you need to set the following parameter in the runtime config (you find a comment in the YAML file too):
+```
+- name: DTYPE_STR
+  value: float32
+```
 ~~~
 oc apply -f ./custom-manifests/caikit/caikit-servingruntime.yaml -n ${TEST_NS}
 ~~~

--- a/demo/kserve/Kserve.md
+++ b/demo/kserve/Kserve.md
@@ -163,14 +163,14 @@ sed "s/<test_ns>/$TEST_NS/g" custom-manifests/service-mesh/peer-authentication-t
 ### Create Caikit ServingRuntime
 
 ~~~
-oc apply -f ./custom-manifests/caikit/caikit-servingruntime.yaml
+oc apply -f ./custom-manifests/caikit/caikit-servingruntime.yaml -n ${TEST_NS}
 ~~~
 
 ### Deploy example model(flan-t5-samll)
 
 ~~~
-oc apply -f ./minio-secret-current.yaml 
-oc create -f ./serviceaccount-minio-current.yaml
+oc apply -f ./minio-secret-current.yaml -n ${TEST_NS} 
+oc create -f ./serviceaccount-minio-current.yaml -n ${TEST_NS}
 
 oc apply -f ./custom-manifests/caikit/caikit-isvc.yaml -n ${TEST_NS}
 ~~~

--- a/demo/kserve/Kserve.md
+++ b/demo/kserve/Kserve.md
@@ -3,6 +3,7 @@
 ## Prerequisite
 - Openshift Cluster 
   - This doc is written based on ROSA cluster
+  - many of the tasks in this tutorial require cluster-admin permission level (e.g., install operators, set service-mesh configuration, enable http2, etc)
 - CLI tools
   - oc cli
 

--- a/demo/kserve/Kserve.md
+++ b/demo/kserve/Kserve.md
@@ -134,6 +134,7 @@ oc apply -f ./custom-manifests/metrics/caikit-metrics-servicemonitor.yaml -n ${T
 
 ## Deploy Minio for example LLM model
 
+You have your model in another S3-like object storage (e.g., AWS S3), you can skip this step.
 ~~~
 ACCESS_KEY_ID=THEACCESSKEY
 SECRET_ACCESS_KEY=$(openssl rand -hex 32)
@@ -167,7 +168,7 @@ oc apply -f ./custom-manifests/caikit/caikit-servingruntime.yaml -n ${TEST_NS}
 ~~~
 
 ### Deploy example model(flan-t5-samll)
-
+You have your model in another S3-like object storage (e.g., AWS S3), you can change according the connection data in the minio-secret.yaml and serviceaccount-minio.yaml from caikit-tgis-serving/demo/kserve/custom-manifests/minio/ path
 ~~~
 oc apply -f ./minio-secret-current.yaml -n ${TEST_NS} 
 oc create -f ./serviceaccount-minio-current.yaml -n ${TEST_NS}

--- a/demo/kserve/custom-manifests/minio/serviceaccount-minio.yaml
+++ b/demo/kserve/custom-manifests/minio/serviceaccount-minio.yaml
@@ -2,10 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: sa
-  annotations:
-    serving.kserve.io/s3-endpoint: minio.<minio_ns>.svc:9000 # replace with your s3 endpoint e.g minio-service.kubeflow:9000
-    serving.kserve.io/s3-usehttps: "0" # by default 1, if testing with minio you can set to 0
-    serving.kserve.io/s3-region: "us-east-2"
-    serving.kserve.io/s3-useanoncredential: "false" # omitting this is the same as false, if true will ignore provided credential and use anonymous credentials
 secrets:
 - name: storage-config


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Few changes in the kserve.md quick start:
- adding `-n $TEST_NS` in some lines (monitoring part not checked yet)
- removing annotation from SA because those are in the secret too
- add a note about using S3 storage different from minio
- add a step to enable http2 if not enabled in the cluster
- add expected model answer

## How Has This Been Tested?
following the quick start on a PSI cluster

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
