### PR TITLE
add instructions according to metrics controller

### DIFF
--- a/demo/kserve/custom-manifests/metrics/kserve-prometheus-k8s.yaml
+++ b/demo/kserve/custom-manifests/metrics/kserve-prometheus-k8s.yaml
@@ -1,0 +1,15 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kserve-prometheus-k8s
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - services
+      - endpoints
+      - pods

--- a/demo/kserve/custom-manifests/opendatahub/kfdef-odh-model-controller.yaml
+++ b/demo/kserve/custom-manifests/opendatahub/kfdef-odh-model-controller.yaml
@@ -1,0 +1,16 @@
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  name: odh-model-controller
+  namespace: kserve
+spec:
+  applications:
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odh-model-controller
+      name: odh-model-controller
+  repos:
+    - name: manifests
+      uri: >-
+        https://github.com/VedantMahabaleshwarkar/odh-manifests/tarball/kserve-metrics

--- a/demo/kserve/custom-manifests/service-mesh/istio-proxies-monitor.yaml
+++ b/demo/kserve/custom-manifests/service-mesh/istio-proxies-monitor.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: istio-proxies-monitor
+  namespace: istio-system
+spec:
+  selector:
+    matchExpressions:
+    - key: istio-prometheus-ignore
+      operator: DoesNotExist
+  podMetricsEndpoints:
+  - path: /stats/prometheus
+    interval: 30s

--- a/demo/kserve/custom-manifests/service-mesh/istiod-monitor.yaml
+++ b/demo/kserve/custom-manifests/service-mesh/istiod-monitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: istiod-monitor
+  namespace: istio-system
+spec:
+  targetLabels:
+  - app
+  selector:
+    matchLabels:
+      istio: pilot
+  endpoints:
+  - port: http-monitoring
+    interval: 30s

--- a/demo/kserve/custom-manifests/service-mesh/smcp.yaml
+++ b/demo/kserve/custom-manifests/service-mesh/smcp.yaml
@@ -11,7 +11,7 @@ spec:
       name: kiali
       enabled: true
     prometheus:
-      enabled: true
+      enabled: false
     jaeger: 
       name: jaeger
   security:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Add instructions to deploy odh-model-controller to automate metrics. 
- Cleaned up a few other instructions

Note: the existing odh-model-controller `overlay` to modelmesh has been kept as it is to minimize any impact of changes to modelmesh functionality 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- This PR should be tested along with corresponding PRs to [odh-manifests](https://github.com/opendatahub-io/odh-manifests/pull/912) and [odh-model-controller](https://github.com/opendatahub-io/odh-model-controller/pull/65)
- To test the new controller : follow the instructions [here](https://github.com/VedantMahabaleshwarkar/caikit-tgis-serving/blob/metrics-controller/demo/kserve/Kserve.md) 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
