### PR TITLE
Remove kfdef for monitoring

### DIFF
--- a/demo/kserve/Kserve.md
+++ b/demo/kserve/Kserve.md
@@ -158,11 +158,6 @@ oc wait --for=condition=ready pod -l name=rhods-operator -n ${TARGET_OPERATOR_NS
 oc create -f custom-manifests/opendatahub/kserve-dsc.yaml
 ~~~
 
-To enable automatic enabling of metrics for deployed models, deploy odh-model-controller 
-~~~
-oc create -f custom-manifests/opendatahub/kfdef-odh-model-controller.yaml
-~~~
-
 ## Deploy Minio for example LLM model
 
 If you have your model in another S3-like object storage (e.g., AWS S3), you can skip this step.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The metrics part need odh-model-controller but it is not enabled with opendatahub v2.0 operator so the instruction needs to be deleted for now. However, it will be added again when @VedantMahabaleshwarkar PRs merged.

- https://github.com/opendatahub-io/opendatahub-operator/pull/438
- https://github.com/opendatahub-io/odh-manifests/pull/912

When above PRs merged, please send a PR to add the metric part @VedantMahabaleshwarkar 

## How Has This Been Tested?
no need to test

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
