### PR TITLE
replace sleep cmd of a watching logic to wait for pod ready

### DIFF
--- a/demo/kserve/scripts/install/kserve-install.sh
+++ b/demo/kserve/scripts/install/kserve-install.sh
@@ -3,6 +3,7 @@
 # - CHECK_UWM: Set this to "false", if you want to skip the User Workload Configmap check message
 # - TARGET_OPERATOR: Set this among odh, rhods or brew, if you want to skip the question in the script.
 source "$(dirname "$(realpath "$0")")/../env.sh"
+source "$(dirname "$(realpath "$0")")/../utils.sh"
 if [[ -n ${CHECK_UWM} && ${CHECK_UWM} == "false" ]]
 then
   input="y"
@@ -86,59 +87,91 @@ mkdir ${BASE_CERT_DIR}
 # cd caikit-tgis-serving/demo/kserve
 
 # Install Service Mesh operators
+echo "[INFO] Install Service Mesh operators"
+echo
 oc apply -f custom-manifests/service-mesh/operators.yaml
-echo
-echo "Wait 30s for servicemesh operators"
-echo
-sleep 30
+
+wait_for_csv_installed servicemeshoperator openshift-operators
+wait_for_csv_installed kiali-operator openshift-operators
+wait_for_csv_installed jaeger-operator openshift-operators
 oc wait --for=condition=ready pod -l name=istio-operator -n openshift-operators --timeout=300s
 oc wait --for=condition=ready pod -l name=jaeger-operator -n openshift-operators --timeout=300s
 oc wait --for=condition=ready pod -l name=kiali-operator -n openshift-operators --timeout=300s
 
 # Create an istio instance
+echo
+echo "[INFO] Create an istio instance"
+echo
 oc create ns istio-system
-sleep 2
+oc::wait::object::availability "oc get project istio-system" 2 60
+
 oc apply -f custom-manifests/service-mesh/smcp.yaml
-echo
-echo "Wait 30s for servicemesh control plane"
-echo
-sleep 30
+wait_for_pods_ready "app=istiod" "istio-system"
+wait_for_pods_ready "app=istio-ingressgateway" "istio-system"
+wait_for_pods_ready "app=istio-egressgateway" "istio-system"
+wait_for_pods_ready "app=jaeger" "istio-system"
+
 oc wait --for=condition=ready pod -l app=istiod -n istio-system --timeout=300s
 oc wait --for=condition=ready pod -l app=istio-ingressgateway -n istio-system --timeout=300s
 oc wait --for=condition=ready pod -l app=istio-egressgateway -n istio-system --timeout=300s
 oc wait --for=condition=ready pod -l app=jaeger -n istio-system --timeout=300s
 
 # kserve/knative
-oc create ns redhat-ods-applications
+echo
+echo "[INFO]Update SMMR"
+echo
+if [[ ${TARGET_OPERATOR_TYPE} == "odh" ]];
+then
+  oc create ns opendatahub
+  oc::wait::object::availability "oc get project opendatahub" 2 60
+else
+  oc create ns redhat-ods-applications
+  oc::wait::object::availability "oc get project redhat-ods-applications" 2 60
+fi
 oc create ns knative-serving
+oc::wait::object::availability "oc get project knative-serving" 2 60
+
 oc apply -f custom-manifests/service-mesh/smmr-${TARGET_OPERATOR_TYPE}.yaml
 oc apply -f custom-manifests/service-mesh/peer-authentication.yaml
 oc apply -f custom-manifests/service-mesh/peer-authentication-${TARGET_OPERATOR_TYPE}.yaml 
 # we need this because of https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/serverless/serving#serverless-domain-mapping-custom-tls-cert_domain-mapping-custom-tls-cert
 
+echo
+echo "[INFO] Install Serverless Operator"
+echo
 oc apply -f custom-manifests/serverless/operators.yaml
-echo
-echo "Wait 60s for serverless operators"
-echo
-sleep 60
+wait_for_csv_installed serverless-operator openshift-serverless
+
+wait_for_pods_ready "name=knative-openshift" "openshift-serverless"
+wait_for_pods_ready "name=knative-openshift-ingress" "openshift-serverless"
+wait_for_pods_ready "name=knative-operator" "openshift-serverless"
 oc wait --for=condition=ready pod -l name=knative-openshift -n openshift-serverless --timeout=300s
 oc wait --for=condition=ready pod -l name=knative-openshift-ingress -n openshift-serverless --timeout=300s
 oc wait --for=condition=ready pod -l name=knative-operator -n openshift-serverless --timeout=300s
 
 # Create a Knative Serving installation
+echo
+echo "[INFO] Create a Knative Serving installation"
+echo
 oc apply -f custom-manifests/serverless/knativeserving-istio.yaml
-echo
-echo "Wait 15s for detecting knative-serving cr"
-echo
-sleep 15
+
+wait_for_pods_ready "app=controller" "knative-serving"
+wait_for_pods_ready "app=net-istio-controller" "knative-serving"
+wait_for_pods_ready "app=net-istio-webhook" "knative-serving"
+wait_for_pods_ready "app=autoscaler-hpa" "knative-serving"
+wait_for_pods_ready "app=domain-mapping" "knative-serving"
+wait_for_pods_ready "app=webhook" "knative-serving"
+oc delete pod -n knative-serving -l app=activator --force --grace-period=0
+oc delete pod -n knative-serving -l app=autoscaler --force --grace-period=0
+wait_for_pods_ready "app=activator" "knative-serving"
+wait_for_pods_ready "app=autoscaler" "knative-serving"
+
 oc wait --for=condition=ready pod -l app=controller -n knative-serving --timeout=300s
 oc wait --for=condition=ready pod -l app=net-istio-controller -n knative-serving --timeout=300s
 oc wait --for=condition=ready pod -l app=net-istio-webhook -n knative-serving --timeout=300s
 oc wait --for=condition=ready pod -l app=autoscaler-hpa -n knative-serving --timeout=300s
 oc wait --for=condition=ready pod -l app=domain-mapping -n knative-serving --timeout=300s
 oc wait --for=condition=ready pod -l app=webhook -n knative-serving --timeout=300s
-oc delete pod -n knative-serving -l app=activator --force --grace-period=0
-oc delete pod -n knative-serving -l app=autoscaler --force --grace-period=0
 oc wait --for=condition=ready pod -l app=activator -n knative-serving --timeout=300s
 oc wait --for=condition=ready pod -l app=autoscaler -n knative-serving --timeout=300s
 
@@ -148,6 +181,9 @@ export COMMON_NAME=$(oc get ingresses.config.openshift.io cluster -o jsonpath='{
 
 # cd ${BASE_CERT_DIR}
 ## Generate wildcard cert using openssl
+echo
+echo "[INFO] Generate wildcard cert using openssl"
+echo
 ./scripts/generate-wildcard-certs.sh ${BASE_CERT_DIR} ${DOMAIN_NAME} ${COMMON_NAME}
 
 # Create the Knative gateways
@@ -158,20 +194,29 @@ oc apply -f custom-manifests/serverless/gateways.yaml
 if [[ ${TARGET_OPERATOR} == "brew" ]];
 then
   echo
-  echo "Create catalogsource for brew registry"
+  echo "[INFO] Create catalogsource for brew registry"
+  echo
   sed "s/<%brew_tag%>/$BREW_TAG/g" custom-manifests/brew/catalogsource.yaml |oc apply -f -
 
+  wait_for_pods_ready "olm.catalogSource=rhods-catalog-dev" "openshift-marketplace"
   oc wait --for=condition=ready pod -l olm.catalogSource=rhods-catalog-dev -n openshift-marketplace --timeout=60s  
 fi
 
 # Deploy odh/rhods operator
-oc create ns redhat-ods-operator
+echo
+echo "[INFO] Deploy odh/rhods operator"
+echo
+if [[ ${TARGET_OPERATOR_TYPE} == "rhods" ]];
+then
+  oc create ns ${TARGET_OPERATOR_NS}
+  oc::wait::object::availability "oc get project ${TARGET_OPERATOR_NS} " 2 60
+fi
 oc create -f custom-manifests/opendatahub/${TARGET_OPERATOR}-operators-2.0.yaml
 
+wait_for_pods_ready "name=rhods-operator" "${TARGET_OPERATOR_NS}"
 oc wait --for=condition=ready pod -l name=rhods-operator -n ${TARGET_OPERATOR_NS} --timeout=300s 
-echo
-echo "Wait 30s for opendatahub operator"
-echo
-sleep 30
-oc create -f custom-manifests/opendatahub/kserve-dsc.yaml
 
+echo
+echo "[INFO] Deploy KServe"
+echo
+oc create -f custom-manifests/opendatahub/kserve-dsc.yaml

--- a/demo/kserve/scripts/test/grpc-call.sh
+++ b/demo/kserve/scripts/test/grpc-call.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 source "$(dirname "$(realpath "$0")")/../env.sh"
+source "$(dirname "$(realpath "$0")")/../utils.sh"
 
 echo
 echo "Wait until runtime is READY"
 
+wait_for_pods_ready "serving.kserve.io/inferenceservice=caikit-example-isvc" "${TEST_NS}"
 oc wait --for=condition=ready pod -l serving.kserve.io/inferenceservice=caikit-example-isvc -n ${TEST_NS} --timeout=300s
 
 echo

--- a/demo/kserve/scripts/uninstall/dependencies-uninstall.sh
+++ b/demo/kserve/scripts/uninstall/dependencies-uninstall.sh
@@ -3,6 +3,7 @@ source "$(dirname "$(realpath "$0")")/../env.sh"
 
 if [[ ! -n ${TARGET_OPERATOR} ]]
   then
+    echo
     read -p "TARGET_OPERATOR is not set. Is it for odh or rhods or brew?" input_target_op
     if [[ $input_target_op == "odh" || $input_target_op == "rhods" || $input_target_op == "brew" ]]
     then

--- a/demo/kserve/scripts/uninstall/kserve-uninstall.sh
+++ b/demo/kserve/scripts/uninstall/kserve-uninstall.sh
@@ -15,6 +15,7 @@ oc delete csv -n redhat-ods-operator rhods-operator.2.0.0
 
 if [[ ! -n ${TARGET_OPERATOR} ]]
   then
+    echo
     read -p "TARGET_OPERATOR is not set. Is it for odh or rhods or brew?" input_target_op
     if [[ $input_target_op == "odh" || $input_target_op == "rhods" || $input_target_op == "brew" ]]
     then

--- a/demo/kserve/scripts/utils.sh
+++ b/demo/kserve/scripts/utils.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+die() {
+  color_red='\e[31m'
+  color_yellow='\e[33m'
+  color_reset='\e[0m'
+  printf "${color_red}FATAL:${color_yellow} $*${color_reset}\n" 1>&2
+  exit 10
+}
+
+info() {
+  color_blue='\e[34m'
+  color_reset='\e[0m'
+  printf "${color_blue}$*${color_reset}\n" 1>&2
+}
+
+success() {
+  color_green='\e[32m'
+  color_reset='\e[0m'
+  printf "${color_green}$*${color_reset}\n" 1>&2
+}
+
+check_pod_status() {
+  local -r JSONPATH="{range .items[*]}{'\n'}{@.metadata.name}:{@.status.phase}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}"
+  local -r pod_selector="$1"
+  local -r pod_namespace="$2"
+  local pod_status
+  local pod_entry
+
+  pod_status=$(oc get pods -l $pod_selector -n $pod_namespace -o jsonpath="$JSONPATH") 
+  oc_exit_code=$? # capture the exit code instead of failing
+
+  if [[ $oc_exit_code -ne 0 ]]; then
+    # kubectl command failed. print the error then wait and retry
+    echo "Error running kubectl command."
+    echo $pod_status
+    return 1
+  elif [[ ${#pod_status} -eq 0 ]]; then
+    echo -n "No pods found with selector $pod_selector in $pod_namespace. Pods may not be up yet."
+    return 1
+  else
+    # split string by newline into array
+    IFS=$'\n' read -r -d '' -a pod_status_array <<<"$pod_status"
+
+    for pod_entry in "${pod_status_array[@]}"; do
+      local pod=$(echo $pod_entry | cut -d ':' -f1)
+      local phase=$(echo $pod_entry | cut -d ':' -f2)
+      local conditions=$(echo $pod_entry | cut -d ':' -f3)
+      if [ "$phase" != "Running" ] && [ "$phase" != "Succeeded" ]; then
+        return 1
+      fi
+      if [[ $conditions != *"Ready=True"* ]]; then
+        return 1
+      fi
+    done
+  fi
+  return 0
+}
+
+wait_for_pods_ready() {
+  local -r JSONPATH="{.items[*]}"
+  local -r pod_selector="$1"
+  local -r pod_namespace=$2
+  local wait_counter=0
+  local oc_exit_code=0
+  local pod_status
+
+  while true; do
+    pod_status=$(oc get pods -l $pod_selector -n $pod_namespace -o jsonpath="$JSONPATH") 
+    oc_exit_code=$? # capture the exit code instead of failing
+
+    if [[ $oc_exit_code -ne 0 ]]; then
+      # kubectl command failed. print the error then wait and retry
+      echo $pod_status
+      echo -n "Error running kubectl command."
+    elif [[ ${#pod_status} -eq 0 ]]; then
+      echo -n "No pods found with selector '$pod_selector' -n '$pod_namespace'. Pods may not be up yet."
+    elif check_pod_status "$pod_selector" "$pod_namespace"; then
+      echo "All $pod_selector pods in '$pod_namespace' namespace are running and ready."
+      return
+    else
+      echo -n "Pods found with selector '$pod_selector' in '$pod_namespace' namespace are not ready yet."
+    fi
+
+    if [[ $wait_counter -ge 60 ]]; then
+      echo
+      oc get pods $pod_selector -n $pod_namespace
+      die "Timed out after $((10 * wait_counter / 60)) minutes waiting for pod with selector: $pod_selector"
+    fi
+
+    wait_counter=$((wait_counter + 1))
+    echo " Waiting 10 secs ..."
+    sleep 10
+  done
+}
+
+function wait_for_csv_installed(){
+    csv=$1
+    namespace=$2
+    ii=0
+    echo
+    echo "[START] Watching if CSV \"$csv\" is installed" 
+    csv_status=$(oc get csv -n $namespace 2>&1 |grep $csv|awk '{print $NF}')
+    while [[ $csv_status != 'Succeeded' ]]
+    do
+        echo -n "."
+        ((ii=ii+1))
+        sleep 2
+
+        if [ $(expr $ii % 20) == "0" ]; then   
+            echo ""
+            echo "CSV \"$csv\" is NOT installed yet" 
+        fi
+
+        csv_status=$(oc get csv -n $namespace 2>&1 |grep $csv|awk '{print $NF}')
+    done
+    echo
+    echo "[END] CSV \"$csv\" is successfully installed" 
+}
+
+function oc::wait::object::availability() {
+    local cmd=$1 # Command whose output we require
+    local interval=$2 # How many seconds to sleep between tries
+    local iterations=$3 # How many times we attempt to run the command
+
+    ii=0
+    echo "[START] Wait for \"${cmd}\" "
+    while [ $ii -le $iterations ]
+    do
+
+        token=$($cmd &>>/dev/null) && returncode=$? || returncode=$?
+        echo "$cmd "|sh
+
+        if [ $returncode -eq 0 ]; then
+            break
+        fi
+
+        ((ii=ii+1))
+        if [ $ii -eq 100 ]; then
+            echo "${cmd} did not return a value$"
+            exit 1
+        fi
+        sleep $interval
+    done
+    echo "[END] \"${cmd}\" is successfully done"
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds an enhanced util logic to wait for a Pod to be ready instead of using sleep cmd.
Mover, I add more detail logs.

## How Has This Been Tested?
Test instruction: https://github.com/opendatahub-io/caikit-tgis-serving/tree/main/demo/kserve/scripts

only 1.31 brew image is working with this script.
~~~
BREW_TAG=554186
~~~

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
