### PR TITLE
Update to use micropipenv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ COPY caikit /caikit
 
 RUN yum -y update && yum -y install git git-lfs && yum clean all && \
     git lfs install && \
-    pip install pipenv && \
-    pipenv install --system && \
+    pip install 'micropipenv[toml]' && \
+    micropipenv install && \
     rm -rf ~/.cache && \
     mkdir -p /opt/models && \
     adduser -g 0 -u 1001 caikit --home-dir /caikit && \


### PR DESCRIPTION
Pipenv is broken at time of PR creation, and we use micropipenv for our notebooks anyway, this allows builds to work again