### PR TITLE
add a parameter for custom manifests url

### DIFF
--- a/demo/kserve/scripts/README.md
+++ b/demo/kserve/scripts/README.md
@@ -34,6 +34,7 @@ export TARGET_OPERATOR=odh
 - CHECK_UWM: Set this to "false", if you want to skip the User Workload Configmap check message
 - TARGET_OPERATOR: Set this among odh, rhods or brew, if you want to skip the question in the script.
 - BREW_TAG: Set this, when you want to choose brew for TARGET_OPERATOR.
+- CUSTOM_MANIFESTS_URL: Set this, when you want to use custom manifests(ex, https://github.com/opendatahub-io/odh-manifests/tarball/master)
   
 
 **Install Kserve including dependencies**

--- a/demo/kserve/scripts/install/kserve-install.sh
+++ b/demo/kserve/scripts/install/kserve-install.sh
@@ -227,6 +227,14 @@ oc create -f custom-manifests/opendatahub/${TARGET_OPERATOR}-operators-2.0.yaml
 wait_for_pods_ready "name=rhods-operator" "${TARGET_OPERATOR_NS}"
 oc wait --for=condition=ready pod -l name=rhods-operator -n ${TARGET_OPERATOR_NS} --timeout=300s 
 
+# Example CUSTOM_MANIFESTS_URL ==> https://github.com/opendatahub-io/odh-manifests/tarball/master
+if [[ -n ${CUSTOM_MANIFESTS_URL} ]]
+then
+  echo
+  echo "Added custom manifest url into default dscinitializations"
+  oc patch dscinitializations default -p="[{\"op\": \"add\", \"path\": \"/spec/manifestsUri\",\"value\": \"${CUSTOM_MANIFESTS_URL}\"}]" --type='json'
+fi
+
 echo
 echo "[INFO] Deploy KServe"
 echo


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Support a custom manifests url parameter to deploy a custom manifests. 

## How Has This Been Tested?
Test instruction: https://github.com/opendatahub-io/caikit-tgis-serving/tree/main/demo/kserve/scripts

only 1.31 brew image is working with this script.
~~~
export TARGET_OPERATOR=brew
export BREW_TAG=559362
export CUSTOM_MANIFESTS_URL=%YOUR_URL%"
export CHECK_UWM=false
~~~

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
