### PR TITLE
add grpc_health_probe binary for the use-cases without kserve

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM quay.io/opendatahub/text-generation-inference:fast-283ec87
 
 USER root
 
+# Add grpc-ecosystem health probe
+ARG GRPC_HEALTH_PROBE_VERSION=v0.4.19
+
 WORKDIR /caikit
 COPY caikit /caikit
 
@@ -14,6 +17,10 @@ RUN yum -y update && yum -y install git git-lfs && yum clean all && \
     adduser -g 0 -u 1001 caikit --home-dir /caikit && \
     chown -R 1001:0 /caikit /opt/models && \
     chmod -R g=u /caikit /opt/models
+
+# This is for the use-cases without kserve
+RUN curl -Lo /usr/local/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+    chmod +x /usr/local/bin/grpc_health_probe
 
 USER 1001
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is for https://github.com/opendatahub-io/caikit-tgis-serving/issues/64

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

It adds a binary into the image so it does not change source. Hence, it does not need to test.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
