### PR TITLE
check correct NS for operator install for ODH

### DIFF
--- a/demo/kserve/scripts/install/kserve-install.sh
+++ b/demo/kserve/scripts/install/kserve-install.sh
@@ -223,10 +223,14 @@ then
   oc::wait::object::availability "oc get project ${TARGET_OPERATOR_NS} " 2 60
 fi
 oc create -f custom-manifests/opendatahub/${TARGET_OPERATOR}-operators-2.x.yaml
-
-wait_for_pods_ready "name=rhods-operator" "${TARGET_OPERATOR_NS}"
-oc wait --for=condition=ready pod -l name=rhods-operator -n ${TARGET_OPERATOR_NS} --timeout=300s 
-
+if [[ ${TARGET_OPERATOR_TYPE} == "rhods" ]];
+then
+  wait_for_pods_ready "name=rhods-operator" "${TARGET_OPERATOR_NS}"
+  oc wait --for=condition=ready pod -l name=rhods-operator -n ${TARGET_OPERATOR_NS} --timeout=300s 
+else 
+  wait_for_pods_ready "name=opendatahub-operator-controller-manager" "openshift-operators"
+  oc wait --for=condition=ready pod -l name=opendatahub-operator-controller-manager -n openshift-operators --timeout=300s 
+fi 
 # Example CUSTOM_MANIFESTS_URL ==> https://github.com/opendatahub-io/odh-manifests/tarball/master
 if [[ -n "${CUSTOM_MANIFESTS_URL+x}" ]]
 then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --> 
## Description
<!--- Describe your changes in detail -->
ODH operator controller manager is always in the `openshift-operators` namespace, even if the operator is installed in another namespace e.g: `opendatahub`. The script incorrectly waits for `rhods-operator` in the `opendatahub` namespace when the selected operator is ODH. This is incorrect. 

Changed script to look for ODH operator pod in `openshift-operators` instead of `opendatahub`.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested corrected script locally as the existing script failed. 
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
