### PR TITLE
Make RHODS/ODH deployment optional

### DIFF
--- a/demo/kserve/scripts/install/kserve-install.sh
+++ b/demo/kserve/scripts/install/kserve-install.sh
@@ -61,11 +61,11 @@ then
     exit 1
 fi
 
-if [[ ! -n "${DEPLOY_RHODS+x}" ]]
+if [[ ! -n "${DEPLOY_OPERATOR+x}" ]]
 then
-  printf "DEPLOY_RHODS is not set: to skip RHODS installation set the value to false. true otherwise\n"
-  read -p ">> Insert DEPLOY_RHODS: " input_deploy
-  export DEPLOY_RHODS=$input_deploy
+  printf "DEPLOY_OPERATOR is not set: to skip RHODS installation set the value to false. true otherwise\n"
+  read -p ">> Insert DEPLOY_OPERATOR: " input_deploy
+  export DEPLOY_OPERATOR=$input_deploy
 fi
 
 if [[ ! -n ${TARGET_OPERATOR+x} ]]
@@ -85,7 +85,7 @@ if [[ ! -n ${TARGET_OPERATOR+x} ]]
   fi
   echo "${TARGET_OPERATOR_TYPE}"
 
-  if [[ ${DEPLOY_RHODS} == "true" ]] && [[ ${TARGET_OPERATOR} == 'brew' ]] && [[ ! -n "${BREW_TAG+x}" ]]
+  if [[ ${DEPLOY_OPERATOR} == "true" ]] && [[ ${TARGET_OPERATOR} == 'brew' ]] && [[ ! -n "${BREW_TAG+x}" ]]
   then
     read -p "BREW_TAG is not set, what is BREW_TAG?" brew_tag
     if [[ $brew_tag =~ ^[0-9]+$ ]]
@@ -147,7 +147,7 @@ oc wait --for=condition=ready pod -l app=jaeger -n istio-system --timeout=300s
 echo
 echo "[INFO]Update SMMR"
 echo
-if [[ ${DEPLOY_RHODS} == "true" ]]
+if [[ ${DEPLOY_OPERATOR} == "true" ]]
   then
     if [[ ${TARGET_OPERATOR_TYPE} == "odh" ]];
     then
@@ -220,7 +220,7 @@ bash -x ./scripts/generate-wildcard-certs.sh ${BASE_CERT_DIR} ${DOMAIN_NAME} ${C
 oc create secret tls wildcard-certs --cert=${BASE_CERT_DIR}/wildcard.crt --key=${BASE_CERT_DIR}/wildcard.key -n istio-system
 oc apply -f custom-manifests/serverless/gateways.yaml
 
-if [[ ${DEPLOY_RHODS} == "true" ]]
+if [[ ${DEPLOY_OPERATOR} == "true" ]]
   then
     # Deploy odh/rhods operator
     echo

--- a/demo/kserve/scripts/install/kserve-install.sh
+++ b/demo/kserve/scripts/install/kserve-install.sh
@@ -220,24 +220,22 @@ bash -x ./scripts/generate-wildcard-certs.sh ${BASE_CERT_DIR} ${DOMAIN_NAME} ${C
 oc create secret tls wildcard-certs --cert=${BASE_CERT_DIR}/wildcard.crt --key=${BASE_CERT_DIR}/wildcard.key -n istio-system
 oc apply -f custom-manifests/serverless/gateways.yaml
 
-# Create brew catalogsource
-if [[ ${TARGET_OPERATOR} == "brew" ]];
-then
-  echo
-  echo "[INFO] Create catalogsource for brew registry"
-  echo
-  sed "s/<%brew_tag%>/$BREW_TAG/g" custom-manifests/brew/catalogsource.yaml |oc apply -f -
-
-  wait_for_pods_ready "olm.catalogSource=rhods-catalog-dev" "openshift-marketplace"
-  oc wait --for=condition=ready pod -l olm.catalogSource=rhods-catalog-dev -n openshift-marketplace --timeout=60s  
-fi
-
 if [[ ${DEPLOY_RHODS} == "true" ]]
   then
     # Deploy odh/rhods operator
     echo
     echo "[INFO] Deploy odh/rhods operator"
     echo
+    # Create brew catalogsource
+    if [[ ${TARGET_OPERATOR} == "brew" ]];
+    then
+      echo
+      echo "[INFO] Create catalogsource for brew registry"
+      echo
+      sed "s/<%brew_tag%>/$BREW_TAG/g" custom-manifests/brew/catalogsource.yaml |oc apply -f -
+      wait_for_pods_ready "olm.catalogSource=rhods-catalog-dev" "openshift-marketplace"
+      oc wait --for=condition=ready pod -l olm.catalogSource=rhods-catalog-dev -n openshift-marketplace --timeout=60s  
+    fi
     OPERATOR_LABEL="control-plane=controller-manager"
     if [[ ${TARGET_OPERATOR_TYPE} == "rhods" ]];
     then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Main goal:
- Optionally deploy RHODS or ODH when running the kserve install script. 

In addition:
- Remove creation of DSC v1alpha1 - expected for ODH 1.10 coming this week (right?)
- Check if CHECK_UWM env variable is set and ask for it otherwise - to be consistent with other variables

## Description
<!--- Describe your changes in detail -->
Adding an Env variable `DEPLOY_OPERATOR` to control if the script must install RHODS/ODH operator during the execution.

## How Has This Been Tested?
Tested by running ./scripts/install/kserve-install.sh as per [README.md](https://github.com/opendatahub-io/caikit-tgis-serving/blob/main/demo/kserve/scripts/README.md)

Scenarios:
- Tested against a cluster where RHODS was already installed and stack not
- Tested against a cluster where both RHODS and stack were installed
- Tested deployment of a model after script execution

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
