### PR TITLE
correct COMMON_NAME generation

### DIFF
--- a/demo/kserve/install-manual.md
+++ b/demo/kserve/install-manual.md
@@ -101,7 +101,7 @@ Note: You have the alternative option of installing the KServe/Caikit/TGIS stack
    export BASE_DIR=/tmp/kserve
    export BASE_CERT_DIR=${BASE_DIR}/certs
    export DOMAIN_NAME=$(oc get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}' | awk -F'.' '{print $(NF-1)"."$NF}')
-   export COMMON_NAME=$(oc get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}'|sed 's/apps.//')
+   export COMMON_NAME=$(oc get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')
 
    mkdir ${BASE_DIR}
    mkdir ${BASE_CERT_DIR}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When the COMMON_NAME for the wildcard certificates was generated, the ".apps" part was removed from the URL. This made the certificate unusable as a wildcard certificate because wildcards are only allowed for one level. So gateway.apps.cluster.domain would not work for SSL as the certificate *.cluster.domain that was generated was not valid for this subdomain.
This prevented gRPC connection with SSL to work.
So far it went unnoticed because all the examples and tests are run with grpcul with the "insecure" flag set. So of course if you don't check anything it works...

## How Has This Been Tested?
Tests in various partners environments where the issue was detected when they followed the procedure.

## Merge criteria:

- [x ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
