### PR TITLE
utils: prevent convert.py from erroring out

### DIFF
--- a/utils/convert.py
+++ b/utils/convert.py
@@ -3,12 +3,18 @@
 import caikit_nlp
 import argparse
 
-parser = argparse.ArgumentParser(prog="convert.py")
-parser.add_argument("--model-path", help="Path of the base HuggingFace model", )
-parser.add_argument("--model-save-path", help="Path to save the Caikit format model to")
 
-args = parser.parse_args()
+def main():
+    parser = argparse.ArgumentParser(prog="convert.py")
+    parser.add_argument("--model-path", help="Path of the base HuggingFace model", )
+    parser.add_argument("--model-save-path", help="Path to save the Caikit format model to")
 
-model = caikit_nlp.text_generation.TextGeneration.bootstrap(args.model_path)
+    args = parser.parse_args()
 
-model.save(model_path=args.model_save_path)
+    model = caikit_nlp.text_generation.TextGeneration.bootstrap(args.model_path)
+
+    model.save(model_path=args.model_save_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
`TextGeneration.__del__` is called while the interpreter is closing, resulting in an harmless `TypeError: 'NoneType' object is not callable` while finalizing `TextGeneration`. Having `model` in `main`'s scope prevents this from happening.