### PR TITLE
Use runtime module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ USER caikit
 ENV CONFIG_FILES=/caikit/config/caikit.yml
 VOLUME ["/caikit/config/"]
 
-CMD ["python",  "-m", "caikit.runtime.grpc_server"]
+CMD ["python",  "-m", "caikit.runtime"]


### PR DESCRIPTION
closes #60 

## Description
Changes CMD to use the combined http+grpc server module

## How Has This Been Tested?
`cd test && bash -x smoke-test.sh`