### PR TITLE
Add GitHub actions smoke test

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,34 @@
+on:
+  push:
+    branches: [main]
+    paths:
+      - "!docs"
+      - "!demo"
+
+  pull_request:
+
+jobs:
+  smoke-test:
+    name: Smoke Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build image
+        run: |
+          cd test
+          docker-compose build
+          # Note: caikit's and tgis images are fairly large, and if we include cached
+          # layers, we easily cross the 25GB mark, hence we'll clean up as much
+          # space as possible to avoid out-of-space failures.
+          # caikit-tgis-serving image: ~4GB
+          # text-generation-inference: ~10GB
+          docker system prune -f
+      - name: Pull tgis image
+        run: |
+          docker pull quay.io/opendatahub/text-generation-inference:stable
+      - name: Test image
+        run: |
+          cd test
+          bash -x smoke-test.sh
+        env:
+          CI: true

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   caikit:
-    # image: quay.io/opendatahub/caikit:latest
+    image: quay.io/opendatahub/caikit-tgis-serving:dev
     build: ..
     volumes:
       - ./caikit_config:/caikit/config

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -eo pipefail
 
 function command_required() {
 	local cmd
@@ -10,29 +10,44 @@ function command_required() {
 	fi
 }
 
-command_required python3
 command_required docker-compose
 command_required git-lfs
 
-if [[ ! -d .venv ]]; then
-	python -m venv .venv || (echo "Failed to create venv. Quitting." >&2 && exit 1)
-fi
-source .venv/bin/activate || (echo "Could not source venv. Quitting" >&2 && exit 1)
-
-pip install git+https://github.com/caikit/caikit-nlp
 if [[ ! -d flan-t5-small ]]; then
 	git clone https://huggingface.co/google/flan-t5-small
 fi
 
 mkdir -p models/
-../utils/convert.py --model-path flan-t5-small --model-save-path models/flan-t5-small-caikit/
+docker-compose build
 
+# use the container's environment to convert the model to caikit format
+docker run --user root \
+	-v $PWD/caikit_config:/caikit/config/ \
+	-v $PWD/flan-t5-small:/mnt/flan-t5-small \
+	-v $PWD/../utils:/utils \
+	-v $PWD/models/:/mnt/models quay.io/opendatahub/caikit-tgis-serving:dev \
+	/utils/convert.py --model-path /mnt/flan-t5-small --model-save-path /mnt/models/flan-t5-small-caikit/
 echo "Saved caikit model to ./models/"
+
+if [[ -n $CI ]]; then # Free up some space on CI
+	rm -rf flan-t5-small
+fi
 
 docker-compose up -d
 
+if [ -f grpcurl ]; then
+	grpcurl=./grpcurl
+elif ! command -v grpcurl >/dev/null; then
+	grpcurl_version="1.8.7"
+	echo "grpcurl not found, downloading v${grpcurl_version}"
+	curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v${grpcurl_version}/grpcurl_${grpcurl_version}_linux_x86_64.tar.gz | tar zxvf - grpcurl
+	grpcurl=./grpcurl
+else
+	grpcurl=grpcurl
+fi
+
 max_retries=10
-until grpcurl -plaintext \
+until ${grpcurl} -plaintext \
 	-d '{"text": "At what temperature celsius does Nitrogen boil?"}' \
 	-H "mm-model-id: flan-t5-small-caikit" \
 	127.0.0.1:8085 \
@@ -41,6 +56,7 @@ until grpcurl -plaintext \
 	max_retries=$((max_retries - 1))
 	if [[ $max_retries -le 0 ]]; then
 		echo "Failed to query grpc service" >&2
+		docker-compose logs
 		docker-compose down
 		exit 1
 	fi


### PR DESCRIPTION
## Description
Use a github actions workflow to run the docker-compose smoke test. This PR also updates the smoke test itself to use  less storage space by using the built container to convert the image to a caikit-compatible format, as well as other minor fixes related to usage in CI environments.