### PR TITLE
add missing pieces for gathering model metrics

### DIFF
--- a/demo/kserve/scripts/install/2-required-crs.sh
+++ b/demo/kserve/scripts/install/2-required-crs.sh
@@ -39,6 +39,11 @@ oc wait --for=condition=ready pod -l app=istiod -n istio-system --timeout=300s
 oc wait --for=condition=ready pod -l app=istio-ingressgateway -n istio-system --timeout=300s
 oc wait --for=condition=ready pod -l app=istio-egressgateway -n istio-system --timeout=300s
 
+# for gathering metrics
+oc apply -f custom-manifests/service-mesh/istiod-monitor.yaml 
+oc apply -f custom-manifests/service-mesh/istio-proxies-monitor.yaml
+oc apply -f custom-manifests/metrics/kserve-prometheus-k8s.yaml
+
 # kserve/knative
 echo
 light_info "[INFO] Update SMMR"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adding the creation of `istio-proxies-monitor `and `istiod-monitor`. 
This is also adding the ClusterRole `kserve-prometheus-k8s`, however I'm in doubt about the need of this line of code, because I noticed this was already created in my cluster before I applied this PR. I'll investigate it, but according to @VedantMahabaleshwarkar this CR should be required

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Following the instructions here: https://github.com/opendatahub-io/caikit-tgis-serving/blob/main/demo/kserve/scripts/README.md 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
