### PR TITLE
docs: fix apiversion in InferenceService and ServingRuntime

### DIFF
--- a/docs/caikit-isvc.yaml
+++ b/docs/caikit-isvc.yaml
@@ -9,7 +9,6 @@ metadata:
 spec:
   predictor:
     model:
-      apiVersion: serving.kserve.io/v1alpha2
       modelFormat:
         name: caikit
       runtime: caikit-runtime


### PR DESCRIPTION
Make apiVersion consistent across the docs example