### PR TITLE
Add TGIS Standalone SR and ISVC

### DIFF
--- a/demo/kserve/custom-manifests/caikit/tgis-isvc.yaml
+++ b/demo/kserve/custom-manifests/caikit/tgis-isvc.yaml
@@ -1,0 +1,16 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  annotations:
+    serving.knative.openshift.io/enablePassthrough: "true"
+    sidecar.istio.io/inject: "true"
+    sidecar.istio.io/rewriteAppHTTPProbers: "true"
+  name: tgis-example-isvc
+spec:
+  predictor:
+    serviceAccountName: sa
+    model:
+      modelFormat:
+        name: pytorch
+      runtime: tgis-runtime
+      storageUri: proto://path/to/model

--- a/demo/kserve/custom-manifests/caikit/tgis-servingruntime.yaml
+++ b/demo/kserve/custom-manifests/caikit/tgis-servingruntime.yaml
@@ -1,0 +1,29 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: ServingRuntime
+metadata:
+  name: tgis-runtime
+spec:
+  multiModel: false
+  supportedModelFormats:
+    - autoSelect: true
+      name: pytorch
+  containers:
+    - name: kserve-container
+      image: quay.io/opendatahub/text-generation-inference:stable
+      command: ["text-generation-launcher"]
+      args: 
+        - "--model-name=/mnt/models/"
+        - "--port=3000"
+        - "--grpc-port=8033"
+      env:
+        - name: TRANSFORMERS_CACHE
+          value: /tmp/transformers_cache
+      # resources: # configure as required
+      #   requests:
+      #     cpu: 8
+      #     memory: 16Gi
+      ports:
+      - containerPort: 8033
+        name: h2c
+        protocol: TCP
+        


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding standalone TGIS ServingRuntime and InferenceService.

## Testing instructions
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Install KServe on a cluster by following instructions [here](https://github.com/opendatahub-io/caikit-tgis-serving/blob/main/demo/kserve/scripts/README.md)
 2. Deploy Minio (or other storage) with a model ([example](https://github.com/opendatahub-io/caikit-tgis-serving/blob/main/demo/kserve/deploy-remove.md)) and create a new namespace (Steps 1, 2a and 2c)
 3. Deploy SR that is in this PR -- add the `namespace` field:
```
apiVersion: serving.kserve.io/v1alpha1
kind: ServingRuntime
metadata:
  name: tgis-runtime
spec:
  multiModel: false
  supportedModelFormats:
    - autoSelect: true
      name: pytorch
  containers:
    - name: kserve-container
      image: quay.io/opendatahub/text-generation-inference:stable
      command: ["text-generation-launcher"]
      args: 
        - "--model-name=/mnt/models/"
        - "--port=3000"
        - "--grpc-port=8033"
      env:
        - name: TRANSFORMERS_CACHE
          value: /tmp/transformers_cache
      # resources: # configure as required
      #   requests:
      #     cpu: 8
      #     memory: 16Gi
      ports:
      - containerPort: 8033
        name: h2c
        protocol: TCP
```
4. Deploy ISVC that is in this PR with edited `storageUri` field -- add the `namespace` field as well:
```
apiVersion: serving.kserve.io/v1beta1
kind: InferenceService
metadata:
  annotations:
    serving.knative.openshift.io/enablePassthrough: "true"
    sidecar.istio.io/inject: "true"
    sidecar.istio.io/rewriteAppHTTPProbers: "true"
  name: tgis-example-isvc
spec:
  predictor:
    serviceAccountName: sa
    model:
      modelFormat:
        name: pytorch
      runtime: tgis-runtime
      storageUri: s3://modelmesh-example-models/llm/models/flan-t5-small-caikit/artifacts
```
5. Verify that the ISVC is ready
`oc get isvc/tgis-example-isvc -n ${TEST_NS}` 
6. Download both of the proto files [here](https://github.com/opendatahub-io/text-generation-inference/tree/main/proto)
7. Perform sample inference call
```
export KSVC_HOSTNAME=$(oc get ksvc tgis-example-isvc-predictor -n ${TEST_NS} -o jsonpath='{.status.url}' | cut -d'/' -f3)
grpcurl -insecure -proto generation.proto \
    -d '{"requests": [{"text":"At what temperature does Nitrogen boil?"}]}' \
    ${KSVC_HOSTNAME}:443 fmaas.GenerationService/Generate
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
