### PR TITLE
Prevent dependencies uninstall script from breaking RHODS

### DIFF
--- a/demo/kserve/scripts/install/2-required-crs.sh
+++ b/demo/kserve/scripts/install/2-required-crs.sh
@@ -39,11 +39,6 @@ oc wait --for=condition=ready pod -l app=istiod -n istio-system --timeout=300s
 oc wait --for=condition=ready pod -l app=istio-ingressgateway -n istio-system --timeout=300s
 oc wait --for=condition=ready pod -l app=istio-egressgateway -n istio-system --timeout=300s
 
-# for gathering metrics
-oc apply -f custom-manifests/service-mesh/istiod-monitor.yaml 
-oc apply -f custom-manifests/service-mesh/istio-proxies-monitor.yaml
-oc apply -f custom-manifests/metrics/kserve-prometheus-k8s.yaml
-
 # kserve/knative
 echo
 light_info "[INFO] Update SMMR"

--- a/demo/kserve/scripts/install/2-required-crs.sh
+++ b/demo/kserve/scripts/install/2-required-crs.sh
@@ -39,6 +39,11 @@ oc wait --for=condition=ready pod -l app=istiod -n istio-system --timeout=300s
 oc wait --for=condition=ready pod -l app=istio-ingressgateway -n istio-system --timeout=300s
 oc wait --for=condition=ready pod -l app=istio-egressgateway -n istio-system --timeout=300s
 
+# for gathering metrics
+oc apply -f custom-manifests/service-mesh/istiod-monitor.yaml 
+oc apply -f custom-manifests/service-mesh/istio-proxies-monitor.yaml
+oc apply -f custom-manifests/metrics/kserve-prometheus-k8s.yaml
+
 # kserve/knative
 echo
 light_info "[INFO] Update SMMR"

--- a/demo/kserve/scripts/uninstall/dependencies-uninstall.sh
+++ b/demo/kserve/scripts/uninstall/dependencies-uninstall.sh
@@ -6,23 +6,6 @@ set -o errtrace
 
 source "$(dirname "$(realpath "$0")")/../env.sh"
 
-if [[ ! -n "${TARGET_OPERATOR+x}" ]]
-  then
-    echo
-    read -p "TARGET_OPERATOR is not set. Is it for odh or rhods or brew?" input_target_op
-    if [[ $input_target_op == "odh" || $input_target_op == "rhods" || $input_target_op == "brew" ]]
-    then
-      export TARGET_OPERATOR=$input_target_op
-      export TARGET_OPERATOR_TYPE=$(getOpType $input_target_op)
-    else 
-      echo "[ERR] Only 'odh' or 'rhods' or 'brew' can be entered"
-      exit 1
-    fi
-  else      
-    export TARGET_OPERATOR_TYPE=$(getOpType $TARGET_OPERATOR)
-  fi
-export KSERVE_OPERATOR_NS=$(getKserveNS)
-
 # Delete the Knative gateways
 oc delete -f custom-manifests/serverless/gateways.yaml
 oc delete ServiceMeshControlPlane minimal -n istio-system
@@ -31,7 +14,6 @@ oc delete -f custom-manifests/serverless/knativeserving-istio.yaml
 oc delete -f custom-manifests/serverless/operators.yaml
 
 oc delete -f custom-manifests/service-mesh/default-smmr.yaml  
-oc delete ns redhat-ods-applications
 oc delete ns knative-serving
 oc delete -f custom-manifests/service-mesh/smcp.yaml
 oc delete ns istio-system


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The uninstall script `caikit-tgis-serving/demo/kserve/scripts/uninstall/dependencies-uninstall.sh` deletes the `redhat-ods-applications` namespace, breaking the RHODS installation.

## Description
- remove line to delete RHODS namespace
- remove unused lines and variables

## How Has This Been Tested?
./scripts/uninstall/dependencies-uninstall.sh

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
