### PR TITLE
fix usage of test_connections in config

### DIFF
--- a/caikit.yml
+++ b/caikit.yml
@@ -12,8 +12,6 @@ model_management:
           - tgis-auto
     tgis-auto:
       type: TGIS-AUTO
-      config:
-        test_connection: true
   initializers:
     default:
       type: LOCAL
@@ -23,3 +21,4 @@ model_management:
             config:
               connection:
                 hostname: localhost:8033
+              test_connections: true

--- a/test/caikit_config/caikit.yml
+++ b/test/caikit_config/caikit.yml
@@ -13,8 +13,6 @@ model_management:
           # - local
     tgis-auto:
       type: TGIS-AUTO
-      config:
-        test_connections: true
   initializers:
     default:
       type: LOCAL
@@ -24,7 +22,7 @@ model_management:
             config:
               connection:
                 hostname: tgis:8033
-                test_connections: true
+              test_connections: true
 
 log:
   formatter: pretty


### PR DESCRIPTION
These options are currently being ignored

Related: caikit/caikit-tgis-backend#49


