### PR TITLE
update installation script for 2.5

### DIFF
--- a/demo/kserve/custom-manifests/caikit/caikit-tgis-isvc-http.yaml
+++ b/demo/kserve/custom-manifests/caikit/caikit-tgis-isvc-http.yaml
@@ -1,0 +1,20 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  annotations:
+    serving.knative.openshift.io/enablePassthrough: "true"
+    sidecar.istio.io/inject: "true"
+    sidecar.istio.io/rewriteAppHTTPProbers: "true"
+  name: caikit-tgis-isvc
+spec:
+  predictor:
+    serviceAccountName: sa
+    model:
+      modelFormat:
+        name: caikit
+      runtime: caikit-tgis-runtime
+      storageUri: s3://modelmesh-example-models/llm/models/flan-t5-small-caikit    # single model here
+      # storageUri: proto://path/to/model # single model here
+      # Example, using a pvc:
+      # storageUri: pvc://caikit-pvc/flan-t5-small-caikit/
+      # Target directory must contain a config.yml

--- a/demo/kserve/custom-manifests/caikit/caikit-tgis-servingruntime-http.yaml
+++ b/demo/kserve/custom-manifests/caikit/caikit-tgis-servingruntime-http.yaml
@@ -1,0 +1,35 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: ServingRuntime
+metadata:
+  name: caikit-tgis-runtime
+spec:
+  multiModel: false
+  supportedModelFormats:
+    # Note: this currently *only* supports caikit format models
+    - autoSelect: true
+      name: caikit
+  containers:
+    - name: kserve-container
+      image: quay.io/opendatahub/text-generation-inference:stable
+      command: ["text-generation-launcher"]
+      args: ["--model-name=/mnt/models/artifacts/"]
+      env:
+        - name: TRANSFORMERS_CACHE
+          value: /tmp/transformers_cache
+      # resources: # configure as required
+      #   requests:
+      #     cpu: 8
+      #     memory: 16Gi
+    - name: transformer-container
+      image: quay.io/opendatahub/caikit-tgis-serving:stable
+      command: ["python", "-m", "caikit.runtime.http_server"]
+      env:
+        - name: RUNTIME_LOCAL_MODELS_DIR
+          value: /mnt/models
+      ports:
+        - containerPort: 8080
+          protocol: TCP
+      # resources: # configure as required
+      #   requests:
+      #     cpu: 8
+      #     memory: 16Gi

--- a/demo/kserve/custom-manifests/opendatahub/kserve-dsc-2.5.yaml
+++ b/demo/kserve/custom-manifests/opendatahub/kserve-dsc-2.5.yaml
@@ -13,11 +13,17 @@ spec:
     codeflare:
       managementState: Removed
     dashboard:
-      managementState: Removed
+      managementState: Managed
     datasciencepipelines:
       managementState: Removed
     kserve:
       managementState: Managed
+      serving:
+        ingressGateway:
+          certificate:
+            type: SelfSigned
+        managementState: Managed
+        name: knative-serving
     modelmeshserving:
       managementState: Removed
     ray:

--- a/demo/kserve/custom-manifests/opendatahub/rhods-operators-2.x.yaml
+++ b/demo/kserve/custom-manifests/opendatahub/rhods-operators-2.x.yaml
@@ -12,7 +12,7 @@ metadata:
   name: rhods-operator
   namespace: redhat-ods-operator
 spec:
-  channel: alpha
+  channel: stable
   installPlanApproval: Automatic
   name: rhods-operator
   source: redhat-operators

--- a/demo/kserve/scripts/install_2.5/1-prerequisite-operators.sh
+++ b/demo/kserve/scripts/install_2.5/1-prerequisite-operators.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Environment variables
+# - CHECK_UWM: Set this to "false", if you want to skip the User Workload Configmap check message
+# - TARGET_OPERATOR: Set this among odh, rhods or brew, if you want to skip the question in the script.
+set -o pipefail
+set -o nounset
+set -o errtrace
+# set -x   #Uncomment this to debug script.
+
+source ./scripts/install/check-env-variables.sh
+source "$(dirname "$(realpath "$0")")/../env.sh"
+source "$(dirname "$(realpath "$0")")/../utils.sh"
+
+
+if [[ ! -d ${BASE_DIR} ]]
+then
+  mkdir ${BASE_DIR}
+fi
+
+if [[ ! -d ${BASE_CERT_DIR} ]]
+then
+  mkdir ${BASE_CERT_DIR}
+fi
+
+echo
+info "Let's install ServiceMesh, OpenDataHub and Serverless operators"
+
+# Install Service Mesh operators
+echo
+light_info "[INFO] Install Service Mesh operators"
+echo
+oc apply -f custom-manifests/service-mesh/operators.yaml
+
+wait_for_csv_installed servicemeshoperator openshift-operators
+oc wait --for=condition=ready pod -l name=istio-operator -n openshift-operators --timeout=300s
+
+echo
+light_info "[INFO] Install Serverless Operator"
+echo
+oc apply -f custom-manifests/serverless/operators.yaml
+wait_for_csv_installed serverless-operator openshift-serverless
+
+wait_for_pods_ready "name=knative-openshift" "openshift-serverless"
+wait_for_pods_ready "name=knative-openshift-ingress" "openshift-serverless"
+wait_for_pods_ready "name=knative-operator" "openshift-serverless"
+oc wait --for=condition=ready pod -l name=knative-openshift -n openshift-serverless --timeout=300s
+oc wait --for=condition=ready pod -l name=knative-openshift-ingress -n openshift-serverless --timeout=300s
+oc wait --for=condition=ready pod -l name=knative-operator -n openshift-serverless --timeout=300s
+
+
+echo
+light_info "[INFO] Deploy odh operator"
+echo
+
+# Create brew catalogsource
+if [[ ${deploy_odh_operator} == "true" ]]
+then
+  if [[ ${TARGET_OPERATOR} == "brew" ]];
+  then
+    echo
+    light_info "[INFO] Create catalogsource for brew registry"
+    echo
+    sed "s/<%brew_tag%>/$BREW_TAG/g" custom-manifests/brew/catalogsource.yaml |oc apply -f -
+
+    wait_for_pods_ready "olm.catalogSource=rhods-catalog-dev" "openshift-marketplace"
+    oc wait --for=condition=ready pod -l olm.catalogSource=rhods-catalog-dev -n openshift-marketplace --timeout=60s  
+  fi
+
+  # Deploy odh/rhods operator
+  OPERATOR_LABEL="control-plane=controller-manager"
+  if [[ ${TARGET_OPERATOR_TYPE} == "rhods" ]];
+  then
+    OPERATOR_LABEL="name=rhods-operator"
+    oc create ns ${TARGET_OPERATOR_NS} -oyaml --dry-run=client | oc apply -f-  
+    oc::wait::object::availability "oc get project ${TARGET_OPERATOR_NS}" 2 60    
+  fi
+  oc create -f custom-manifests/opendatahub/${TARGET_OPERATOR}-operators-2.x.yaml
+
+  wait_for_pods_ready "${OPERATOR_LABEL}" "${TARGET_OPERATOR_NS}"
+  oc wait --for=condition=ready pod -l ${OPERATOR_LABEL} -n ${TARGET_OPERATOR_NS} --timeout=300s 
+
+else
+  light_info "DEPLOY_ODH_OPERATOR set ${deploy_odh_operator}. Skip deploy odh/rhods operator" 
+fi
+
+success "[SUCCESS] Successfully installed ServiceMesh, Serverless, OpenDataHub(OpenShiftAI) operators" 

--- a/demo/kserve/scripts/install_2.5/2-verify-istio.sh
+++ b/demo/kserve/scripts/install_2.5/2-verify-istio.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Environment variables
+# - CHECK_UWM: Set this to "false", if you want to skip the User Workload Configmap check message
+# - TARGET_OPERATOR: Set this among odh, rhods or brew, if you want to skip the question in the script.
+set -o pipefail
+set -o nounset
+set -o errtrace
+# set -x   #Uncomment this to debug script.
+
+source "$(dirname "$(realpath "$0")")/../env.sh"
+source "$(dirname "$(realpath "$0")")/../utils.sh"
+
+# Create an istio instance
+echo
+light_info "[INFO] Verify istio pods"
+echo
+
+oc::wait::object::availability "oc get project istio-system" 2 60    
+oc::wait::object::availability "oc get smcp data-science-smcp -n istio-system" 2 60    
+
+if [[ -n ${PLATFORM+x} ]] && [[ $PLATFORM == "rosa" ]]
+then
+  oc patch smcp data-science-smcp --type merge --patch   '{"spec":{"security":{"identity":{"type":"ThirdParty"}}}}' -n istio-system
+fi
+
+wait_for_pods_ready "app=istiod" "istio-system"
+wait_for_pods_ready "app=istio-ingressgateway" "istio-system"
+wait_for_pods_ready "app=istio-egressgateway" "istio-system"
+
+oc wait --for=condition=ready pod -l app=istiod -n istio-system --timeout=300s
+oc wait --for=condition=ready pod -l app=istio-ingressgateway -n istio-system --timeout=300s
+oc wait --for=condition=ready pod -l app=istio-egressgateway -n istio-system --timeout=300s
+
+success "[SUCCESS] ISTIO pods are running properly" 

--- a/demo/kserve/scripts/install_2.5/3-kserve-install.sh
+++ b/demo/kserve/scripts/install_2.5/3-kserve-install.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Environment variables
+# - CHECK_UWM: Set this to "false", if you want to skip the User Workload Configmap check message
+# - TARGET_OPERATOR: Set this among odh, rhods or brew, if you want to skip the question in the script.
+set -o pipefail
+set -o nounset
+set -o errtrace
+# set -x   #Uncomment this to debug script.
+
+if [[ ! -n ${BASE_DIR+} ]];
+then
+  source ./scripts/install/check-env-variables.sh
+fi
+
+source "$(dirname "$(realpath "$0")")/../utils.sh"
+
+if [[ ! -n "${CHECK_UWM+x}" ||  ! -n ${TARGET_OPERATOR+x}  ]]
+then
+  source ./scripts/install/check-env-variables.sh
+fi
+
+echo
+info "[INFO] Create DataScienceCluster"
+echo
+
+dsc_name=$(oc get dsc --no-headers|awk '{print $1}')
+if [[ ${dsc_name} != "" ]]
+then
+  oc patch datasciencecluster ${dsc_name} --type=merge -p '{"spec": {"components":{"kserve": {"managementState": "Managed"}}}}'
+else
+  oc create -f custom-manifests/opendatahub/kserve-dsc-2.5.yaml
+fi
+wait_for_pods_ready "control-plane=kserve-controller-manager" "${KSERVE_OPERATOR_NS}"
+
+# Example CUSTOM_MANIFESTS_URL ==> https://github.com/opendatahub-io/odh-manifests/tarball/master
+if [[ -n "${CUSTOM_MANIFESTS_URL+x}" ]]
+then
+  echo
+  light_info "Added custom manifest url into default dsc"
+  oc patch dsc ${dsc_name} -p="[{\"op\": \"add\", \"path\": \"/spec/components/kserve\",\"value\": \"${CUSTOM_MANIFESTS_URL}\"}]" --type='json'
+
+  light_info "Restart kserve with a new custom manifest"
+  oc delete deploy -l control-plane=kserve-controller-manager "${KSERVE_OPERATOR_NS}"
+  wait_for_pods_ready "control-plane=kserve-controller-manager" "${KSERVE_OPERATOR_NS}"
+fi
+
+# Create a Knative Serving installation
+echo
+light_info "[INFO] Verify a Knative Serving"
+echo
+
+wait_for_pods_ready "app=controller" "knative-serving"
+wait_for_pods_ready "app=net-istio-controller" "knative-serving"
+wait_for_pods_ready "app=net-istio-webhook" "knative-serving"
+wait_for_pods_ready "app=autoscaler-hpa" "knative-serving"
+wait_for_pods_ready "app=domain-mapping" "knative-serving"
+wait_for_pods_ready "app=webhook" "knative-serving"
+wait_for_pods_ready "app=activator" "knative-serving"
+wait_for_pods_ready "app=autoscaler" "knative-serving"
+
+oc wait --for=condition=ready pod -l app=controller -n knative-serving --timeout=300s
+oc wait --for=condition=ready pod -l app=net-istio-controller -n knative-serving --timeout=300s
+oc wait --for=condition=ready pod -l app=net-istio-webhook -n knative-serving --timeout=300s
+oc wait --for=condition=ready pod -l app=autoscaler-hpa -n knative-serving --timeout=300s
+oc wait --for=condition=ready pod -l app=domain-mapping -n knative-serving --timeout=300s
+oc wait --for=condition=ready pod -l app=webhook -n knative-serving --timeout=300s
+oc wait --for=condition=ready pod -l app=activator -n knative-serving --timeout=300s
+oc wait --for=condition=ready pod -l app=autoscaler -n knative-serving --timeout=300s
+
+success "[SUCCESS] KNative pods are running properly" 
+success "[SUCCESS] Successfully deployed KServe operator! Ready for demo" 

--- a/demo/kserve/scripts/install_2.5/check-env-variables.sh
+++ b/demo/kserve/scripts/install_2.5/check-env-variables.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Environment variables
+# - CHECK_UWM: Set this to "false", if you want to skip the User Workload Configmap check message
+# - TARGET_OPERATOR: Set this among odh, rhods or brew, if you want to skip the question in the script.
+set -o pipefail
+set -o nounset
+set -o errtrace
+# set -x   #Uncomment this to debug script.
+
+source "$(dirname "$(realpath "$0")")/../env.sh"
+source "$(dirname "$(realpath "$0")")/../utils.sh"
+if [[ -n "${CHECK_UWM+x}" && ${CHECK_UWM} == "false" ]]
+then
+  input="y"
+else
+  echo "** Check User Workload Configmap for Kserve metrics before you execute this script **"
+  echo 
+  cat <<EOF
+
+  $ oc get cm cluster-monitoring-config -n openshift-monitoring -o yaml
+
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: cluster-monitoring-config
+    namespace: openshift-monitoring
+  data:
+    config.yaml: |
+      enableUserWorkload: true    #<==== Check this part
+
+  ---
+
+  $ oc get cm user-workload-monitoring-config -n openshift-user-workload-monitoring -o yaml
+
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: user-workload-monitoring-config
+    namespace: openshift-user-workload-monitoring
+  data:
+    config.yaml: |
+      prometheus:
+        logLevel: debug 
+        retention: 15d #Change as needed  <==Check this
+EOF
+
+  echo
+  read -p "Have you checked if user workload configmap is set correctly? (then enter 'y')" input
+fi
+
+if [ "$input" != "y" ];
+then
+    echo "ERROR: Please check the configmap and execute this script again"
+    exit 1
+fi
+
+if [[ -n "${DEPLOY_ODH_OPERATOR+x}" ]]
+then  
+  deploy_odh_operator=${DEPLOY_ODH_OPERATOR}
+fi
+
+if [[ ! -n ${TARGET_OPERATOR+x} ]]
+then
+  read -p "TARGET_OPERATOR is not set. Is it for odh or rhods or brew?" input_target_op
+  if [[ $input_target_op == "odh" || $input_target_op == "rhods" || $input_target_op == "brew" ]]
+  then
+    export TARGET_OPERATOR=$input_target_op
+    export TARGET_OPERATOR_TYPE=$(getOpType $input_target_op)
+  else 
+    echo "[ERR] Only 'odh' or 'rhods' or 'brew' can be used"
+    exit 1
+  fi
+else      
+  export TARGET_OPERATOR_TYPE=$(getOpType $TARGET_OPERATOR)
+fi
+echo "${TARGET_OPERATOR_TYPE}"
+
+if [[ ${deploy_odh_operator} == "true" ]] && [[ ${TARGET_OPERATOR} == 'brew' ]] && [[ ! -n "${BREW_TAG+x}" ]]
+then
+  read -p "BREW_TAG is not set, what is BREW_TAG?" brew_tag
+  if [[ $brew_tag =~ ^[0-9]+$ ]]
+  then
+    export BREW_TAG=$brew_tag
+  else 
+    echo "[ERR] BREW_TAG must be number only"
+    exit 1
+  fi      
+fi
+
+# It does not check if the files exist
+if [[ -n ${CUSTOM_CERT+x}  && ! -n ${CUSTOM_KEY+x} ]]; then
+    die "ERROR: CUSTOM_KEY must be set if CUSTOM_CERT is set."
+elif [[ ! -n ${CUSTOM_CERT+x} && -n ${CUSTOM_KEY+x} ]]; then
+    die "ERROR: CUSTOM_CERT must be set if CUSTOM_KEY is set."
+elif  [[ -n ${CUSTOM_CERT+x} && -n ${CUSTOM_KEY+x} ]]; then
+    info "Both CUSTOM_CERT and CUSTOM_KEY are set."
+    info "Knative gateway will use them "
+else
+    info "Neither CUSTOM_CERT nor CUSTOM_KEY is set."
+    info "self signed cert will be generated but do not use it for production"
+fi
+
+export KSERVE_OPERATOR_NS=$(getKserveNS)
+export TARGET_OPERATOR_NS=$(getOpNS ${TARGET_OPERATOR_TYPE})
+
+success "[SUCCESS] Successfully get all environment variables" 

--- a/demo/kserve/scripts/install_2.5/kserve-install.sh
+++ b/demo/kserve/scripts/install_2.5/kserve-install.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Environment variables
+# - CHECK_UWM: Set this to "false", if you want to skip the User Workload Configmap check message
+# - TARGET_OPERATOR: Set this among odh, rhods or brew, if you want to skip the question in the script.
+set -o pipefail
+set -o nounset
+set -o errtrace
+# set -x   #Uncomment this to debug script.
+
+source "$(dirname "$(realpath "$0")")/../env.sh"
+source "$(dirname "$(realpath "$0")")/../utils.sh"
+
+source ./scripts/install/check-env-variables.sh
+./scripts/install_2.5/1-prerequisite-operators.sh
+./scripts/install_2.5/2-verify-istio.sh
+./scripts/install_2.5/3-kserve-install.sh

--- a/demo/kserve/scripts/test/deploy-model-grpc.sh
+++ b/demo/kserve/scripts/test/deploy-model-grpc.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -o pipefail
+set -o nounset
+set -o errtrace
+# set -x   #Uncomment this to debug script.
+
+source "$(dirname "$(realpath "$0")")/../env.sh"
+
+# Check if at most one argument is passed
+if [ "$#" -gt 1 ]; then
+    echo "Error: at most a single argument ('http' or 'grpc') or no argument, default protocol being 'http'"
+    exit 1
+fi
+
+# Default values that fit the default 'http' protocol:
+INF_PROTO="grpc"
+
+
+# Deploy Minio
+ACCESS_KEY_ID=THEACCESSKEY
+
+## Check if ${MINIO_NS} exist
+oc get ns ${MINIO_NS}
+if [[ $? ==  1 ]]
+then
+  oc new-project ${MINIO_NS}
+  SECRET_ACCESS_KEY=$(openssl rand -hex 32)
+  sed "s/<accesskey>/$ACCESS_KEY_ID/g"  ./custom-manifests/minio/minio.yaml | sed "s+<secretkey>+$SECRET_ACCESS_KEY+g" | tee ${BASE_DIR}/minio-current.yaml | oc -n ${MINIO_NS} apply -f -
+  sed "s/<accesskey>/$ACCESS_KEY_ID/g" ./custom-manifests/minio/minio-secret.yaml | sed "s+<secretkey>+$SECRET_ACCESS_KEY+g" |sed "s/<minio_ns>/$MINIO_NS/g" | tee ${BASE_DIR}/minio-secret-current.yaml | oc -n ${MINIO_NS} apply -f - 
+else
+  SECRET_ACCESS_KEY=$(oc get pod minio  -n minio -ojsonpath='{.spec.containers[0].env[1].value}')
+  sed "s/<accesskey>/$ACCESS_KEY_ID/g"  ./custom-manifests/minio/minio.yaml | sed "s+<secretkey>+$SECRET_ACCESS_KEY+g" | tee ${BASE_DIR}/minio-current.yaml 
+  sed "s/<accesskey>/$ACCESS_KEY_ID/g" ./custom-manifests/minio/minio-secret.yaml | sed "s+<secretkey>+$SECRET_ACCESS_KEY+g" |sed "s/<minio_ns>/$MINIO_NS/g" | tee ${BASE_DIR}/minio-secret-current.yaml 
+fi
+sed "s/<minio_ns>/$MINIO_NS/g" ./custom-manifests/minio/serviceaccount-minio.yaml | tee ${BASE_DIR}/serviceaccount-minio-current.yaml 
+
+# Test if ${TEST_NS} namespace already exists:
+oc get ns ${TEST_NS}
+if [[ $? ==  1 ]]
+then
+    echo "Create test namespace: ${TEST_NS}"
+    oc new-project ${TEST_NS}    
+else
+  echo 
+  echo "* ${TEST_NS} exist."
+fi
+
+oc get isvc caikit-tgis-isvc-grpc --no-headers >/dev/null
+if [[ $? ==  1 ]] 
+then
+  echo "GRPC ISVC is creating"
+
+  oc apply -f ./custom-manifests/caikit/caikit-tgis-servingruntime-${INF_PROTO}.yaml -n ${TEST_NS}
+
+  oc apply -f ${BASE_DIR}/minio-secret-current.yaml -n ${TEST_NS} 
+  oc apply -f ${BASE_DIR}/serviceaccount-minio-current.yaml -n ${TEST_NS}
+
+  ###  create the isvc.   First step: create the yaml file
+  ISVC_NAME=caikit-tgis-isvc-${INF_PROTO}
+  oc apply -f ./custom-manifests/caikit/"$ISVC_NAME".yaml -n ${TEST_NS}
+
+  # Resources needed to enable metrics for the model 
+  # The metrics service needs the correct label in the `matchLabel` field. The expected value of this label is `<isvc-name>-predictor-default`
+  # The metrics service in this repo is configured to work with the example model. If you are deploying a different model or using a different model name, change the label accordingly.
+
+  ### TBD: Following 2 line should take into account the changed names 
+  # oc apply -f custom-manifests/metrics/caikit-metrics-service.yaml -n ${TEST_NS}
+  # oc apply -f custom-manifests/metrics/caikit-metrics-servicemonitor.yaml -n ${TEST_NS}
+else
+  echo "* The ISVC already exist. Please remove the isvc or create other isvc"
+fi

--- a/demo/kserve/scripts/test/deploy-model-http.sh
+++ b/demo/kserve/scripts/test/deploy-model-http.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -o pipefail
+set -o nounset
+set -o errtrace
+# set -x   #Uncomment this to debug script.
+
+source "$(dirname "$(realpath "$0")")/../env.sh"
+
+# Check if at most one argument is passed
+if [ "$#" -gt 1 ]; then
+    echo "Error: at most a single argument ('http' or 'grpc') or no argument, default protocol being 'http'"
+    exit 1
+fi
+
+# Default values that fit the default 'http' protocol:
+INF_PROTO="http"
+
+# Deploy Minio
+ACCESS_KEY_ID=THEACCESSKEY
+
+## Check if ${MINIO_NS} exist
+oc get ns ${MINIO_NS}
+if [[ $? ==  1 ]]
+then
+  oc new-project ${MINIO_NS}
+  SECRET_ACCESS_KEY=$(openssl rand -hex 32)
+  sed "s/<accesskey>/$ACCESS_KEY_ID/g"  ./custom-manifests/minio/minio.yaml | sed "s+<secretkey>+$SECRET_ACCESS_KEY+g" | tee ${BASE_DIR}/minio-current.yaml | oc -n ${MINIO_NS} apply -f -
+  sed "s/<accesskey>/$ACCESS_KEY_ID/g" ./custom-manifests/minio/minio-secret.yaml | sed "s+<secretkey>+$SECRET_ACCESS_KEY+g" |sed "s/<minio_ns>/$MINIO_NS/g" | tee ${BASE_DIR}/minio-secret-current.yaml | oc -n ${MINIO_NS} apply -f - 
+else
+  SECRET_ACCESS_KEY=$(oc get pod minio  -n minio -ojsonpath='{.spec.containers[0].env[1].value}')
+  sed "s/<accesskey>/$ACCESS_KEY_ID/g"  ./custom-manifests/minio/minio.yaml | sed "s+<secretkey>+$SECRET_ACCESS_KEY+g" | tee ${BASE_DIR}/minio-current.yaml 
+  sed "s/<accesskey>/$ACCESS_KEY_ID/g" ./custom-manifests/minio/minio-secret.yaml | sed "s+<secretkey>+$SECRET_ACCESS_KEY+g" |sed "s/<minio_ns>/$MINIO_NS/g" | tee ${BASE_DIR}/minio-secret-current.yaml 
+fi
+sed "s/<minio_ns>/$MINIO_NS/g" ./custom-manifests/minio/serviceaccount-minio.yaml | tee ${BASE_DIR}/serviceaccount-minio-current.yaml 
+
+# Test if ${TEST_NS} namespace already exists:
+oc get ns ${TEST_NS}
+if [[ $? ==  1 ]]
+then
+    echo "Create test namespace: ${TEST_NS}"
+    oc new-project ${TEST_NS}    
+else
+  echo 
+  echo "* ${TEST_NS} exist. Please remove the namespace or use another namespace name"
+fi
+
+oc get isvc caikit-tgis-isvc --no-headers >/dev/null
+if [[ $? ==  1 ]] 
+then
+  echo "HTTP ISVC is creating"
+
+  oc apply -f ./custom-manifests/caikit/caikit-tgis-servingruntime-${INF_PROTO}.yaml -n ${TEST_NS}
+
+  oc apply -f ${BASE_DIR}/minio-secret-current.yaml -n ${TEST_NS} 
+  oc apply -f ${BASE_DIR}/serviceaccount-minio-current.yaml -n ${TEST_NS}
+
+  ###  create the isvc.   First step: create the yaml file
+  ISVC_NAME=caikit-tgis-isvc-${INF_PROTO}
+  oc apply -f ./custom-manifests/caikit/$ISVC_NAME.yaml -n ${TEST_NS}
+
+  # Resources needed to enable metrics for the model 
+  # The metrics service needs the correct label in the `matchLabel` field. The expected value of this label is `<isvc-name>-predictor-default`
+  # The metrics service in this repo is configured to work with the example model. If you are deploying a different model or using a different model name, change the label accordingly.
+
+  ### TBD: Following 2 line should take into account the changed names 
+  # oc apply -f custom-manifests/metrics/caikit-metrics-service.yaml -n ${TEST_NS}
+  # oc apply -f custom-manifests/metrics/caikit-metrics-servicemonitor.yaml -n ${TEST_NS}
+else
+  echo "* The ISVC already exist. Please remove the isvc or create other isvc"
+fi

--- a/demo/kserve/scripts/test/grpc-console.sh
+++ b/demo/kserve/scripts/test/grpc-console.sh
@@ -15,10 +15,10 @@ source "$(dirname "$(realpath "$0")")/../utils.sh"
 echo
 echo "Wait until runtime is READY"
 
-wait_for_pods_ready "serving.kserve.io/inferenceservice=caikit-example-isvc" "${TEST_NS}"
-oc wait --for=condition=ready pod -l serving.kserve.io/inferenceservice=caikit-example-isvc -n ${TEST_NS} --timeout=300s
+wait_for_pods_ready "serving.kserve.io/inferenceservice=caikit-tgis-isvc-grpc" "${TEST_NS}"
+oc wait --for=condition=ready pod -l serving.kserve.io/inferenceservice=caikit-tgis-isvc-grpc -n ${TEST_NS} --timeout=300s
 
-export KSVC_HOSTNAME=$(oc get ksvc caikit-example-isvc-predictor -n ${TEST_NS} -o jsonpath='{.status.url}' | cut -d'/' -f3)
+export KSVC_HOSTNAME=$(oc get ksvc caikit-tgis-isvc-grpc-predictor -n ${TEST_NS} -o jsonpath='{.status.url}' | cut -d'/' -f3)
 
 echo "test namespace: $TEST_NS"
 echo "ksvc hostname: $KSVC_HOSTNAME"
@@ -27,4 +27,3 @@ while true; do
 	read -p "> " question
 	grpcurl -insecure -d "{\"text\": \"${question}\"}" -H "mm-model-id: flan-t5-small-caikit" ${KSVC_HOSTNAME}:443 caikit.runtime.Nlp.NlpService/TextGenerationTaskPredict | jq .generated_text
 done
-

--- a/demo/kserve/scripts/uninstall_2.5/dependencies-uninstall.sh
+++ b/demo/kserve/scripts/uninstall_2.5/dependencies-uninstall.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -o pipefail
+set -o nounset
+set -o errtrace
+# set -x   #Uncomment this to debug script.
+
+source "$(dirname "$(realpath "$0")")/../env.sh"
+
+oc delete ServiceMeshControlPlane,pod --all -n istio-system --force --grace-period=0
+oc delete KnativeServing,pod --all -n knative-serving --force --grace-period=0
+oc delete ns knative-serving
+
+oc delete ns istio-system
+
+oc delete -f custom-manifests/service-mesh/operators.yaml
+oc delete -f custom-manifests/serverless/operators.yaml
+
+if [[ -n "${BASE_DIR+x}"  ]] && [[ -n "${BASE_CERT_DIR+x}" ]]
+then
+  if [[ ! z$BASE_DIR == 'z' ]]
+  then
+    rm -rf /${BASE_DIR}
+    rm -rf /${BASE_CERT_DIR}
+  fi
+fi
+
+# Verify 
+
+oc delete KnativeServing knative-serving -n knative-serving
+oc delete subscription servicemeshoperator -n openshift-operators
+oc delete subscription serverless-operator -n openshift-serverless
+
+sm_csv_name=$(oc get csv -n openshift-operators | grep servicemeshoperator|awk '{print $1}')
+oc delete csv $sm_csv_name -n openshift-operators
+
+sl_csv_name=$(oc get csv -n openshift-operators | grep serverless-operator|awk '{print $1}')
+oc delete csv $sm_csv_name -n openshift-serverless
+
+oc delete csv OperatorGroup serverless-operators -n openshift-serverless
+
+oc delete project istio-system
+oc delete project knative-serving
+oc delete project knative-eventing
+oc delete project openshift-serverless
+
+oc get ns ${TEST_NS}
+if [[ $? ==  0 ]]
+then
+    oc delete project $TEST_NS
+fi

--- a/demo/kserve/scripts/uninstall_2.5/kserve-uninstall.sh
+++ b/demo/kserve/scripts/uninstall_2.5/kserve-uninstall.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -o pipefail
+set -o nounset
+set -o errtrace
+# set -x   #Uncomment this to debug script.
+
+# Uninstalls the minio namespace as well as protocol specific namespaces such as kserve-demo-http or hserve-demo-grpc
+
+source "$(dirname "$(realpath "$0")")/../env.sh"
+
+if [[ ! -n "${TARGET_OPERATOR+x}" ]]
+  then
+    echo
+    read -p "TARGET_OPERATOR is not set. Is it for odh or rhods or brew?" input_target_op
+    if [[ $input_target_op == "odh" || $input_target_op == "rhods" || $input_target_op == "brew" ]]
+    then
+      export TARGET_OPERATOR=$input_target_op
+      export TARGET_OPERATOR_TYPE=$(getOpType $input_target_op)
+    else 
+      echo "[ERR] Only 'odh' or 'rhods' or 'brew' can be entered"
+      exit 1
+    fi
+  else      
+    export TARGET_OPERATOR_TYPE=$(getOpType $TARGET_OPERATOR)
+  fi
+export KSERVE_OPERATOR_NS=$(getKserveNS)
+export TARGET_OPERATOR_NS=$(getOpNS ${TARGET_OPERATOR_TYPE})
+
+oc delete validatingwebhookconfiguration inferencegraph.serving.kserve.io  inferenceservice.serving.kserve.io 
+oc delete mutatingwebhookconfiguration inferenceservice.serving.kserve.io
+oc delete isvc,pod --all -n ${TEST_NS} --force --grace-period=0
+
+echo "It would take around around 3~4 mins"
+oc delete ns ${TEST_NS} ${MINIO_NS} --force --grace-period=0
+
+oc delete DataScienceCluster --all -n "${KSERVE_OPERATOR_NS}"
+sleep 15
+oc delete sub "${TARGET_OPERATOR_TYPE}-operator" -n ${TARGET_OPERATOR_NS}
+  
+if [[ ${TARGET_OPERATOR} == "brew" ]];
+then  
+  oc delete catalogsource rhods-catalog-dev -n openshift-marketplace
+fi
+if [[ ${TARGET_OPERATOR_TYPE} == "rhods" ]]; then
+  if [[ -n ${CLEAN_NS+x} && ${CLEAN_NS} != "false" ]]
+  then
+    oc delete ns redhat-ods-operator redhat-ods-applications rhods-notebooks redhat-ods-monitoring --force --grace-period=0
+  fi
+  oc delete csv -n ${TARGET_OPERATOR_NS} $(oc get csv -n ${TARGET_OPERATOR_NS}|grep rhods|awk '{print $1}')
+else
+  if [[ -n ${CLEAN_NS+x} && ${CLEAN_NS} != "false" ]]
+  then  
+    oc delete ns ${KSERVE_OPERATOR_NS} --force --grace-period=0
+  fi
+  oc delete csv -n ${TARGET_OPERATOR_NS} $(oc get csv -n ${TARGET_OPERATOR_NS} |grep opendatahub|awk '{print $1}')
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This add new scripts for 2.5 odh/rhods operator.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

After you login to a new fresh openshift cluster, then execute these commands
~~~
git clone git@github.com:Jooho/caikit-tgis-serving.git
cd caikit-tgis-serving/demo/kserve

# Install kserve + dependencies
export TARGET_OPERATOR=rhods
export CHECK_UWM=false

# If you are using ROSA, please add this too
# export PLATFORM=rosa 

./scripts/install_2.5/kserve-install.sh

# Deploy model
./scripts/test/deploy-model-grpc.sh
./scripts/test/deploy-model-http.sh

# Test
./scripts/test/grpc-call.sh
./scripts/test/http-call.sh

# Delete isvc/minio
./scripts/test/delete-model.sh

# Uninstall kserve and dependencies
./scripts/uninstall_2.5/kserve-uninstall.sh
./scripts/uninstall_2.5/dependencies-uninstall.sh
~~~


