### PR TITLE
gha: try to free more disk space

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -15,6 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+
       - name: Build image
         run: |
           cd test


### PR DESCRIPTION
The text-generation-inference image is fairly large, and pulling it might make the test fail because of an out-of-space error, we want to try to free up as much space as possible.