### PR TITLE
manifests: remove grpconly label

### DIFF
--- a/demo/kserve/custom-manifests/caikit/caikit-standalone/caikit-standalone-isvc-grpc-template.yaml
+++ b/demo/kserve/custom-manifests/caikit/caikit-standalone/caikit-standalone-isvc-grpc-template.yaml
@@ -5,8 +5,6 @@ metadata:
     serving.knative.openshift.io/enablePassthrough: "true"
     sidecar.istio.io/inject: "true"
     sidecar.istio.io/rewriteAppHTTPProbers: "true"
-  labels:
-    protocol: "grpconly" # workaround for https://issues.redhat.com/browse/RHOAIENG-165
   name: caikit-standalone-isvc-grpc
 spec:
   predictor:

--- a/demo/kserve/custom-manifests/caikit/caikit-standalone/caikit-standalone-isvc-grpc.yaml
+++ b/demo/kserve/custom-manifests/caikit/caikit-standalone/caikit-standalone-isvc-grpc.yaml
@@ -5,8 +5,6 @@ metadata:
     serving.knative.openshift.io/enablePassthrough: "true"
     sidecar.istio.io/inject: "true"
     sidecar.istio.io/rewriteAppHTTPProbers: "true"
-  labels:
-    protocol: "grpconly" # workaround for https://issues.redhat.com/browse/RHOAIENG-165
   name: caikit-standalone-isvc-grpc
 spec:
   predictor:

--- a/demo/kserve/custom-manifests/caikit/caikit-tgis/caikit-tgis-isvc-grpc-template.yaml
+++ b/demo/kserve/custom-manifests/caikit/caikit-tgis/caikit-tgis-isvc-grpc-template.yaml
@@ -5,8 +5,6 @@ metadata:
     serving.knative.openshift.io/enablePassthrough: "true"
     sidecar.istio.io/inject: "true"
     sidecar.istio.io/rewriteAppHTTPProbers: "true"
-  labels:
-    protocol: "grpconly" # workaround for https://issues.redhat.com/browse/RHOAIENG-165
   # The following <caikit-tgis-isvc-name> should be set to the
   # actual name of the inference service. (e.g., caikit-tgis-isvc
   # for HTTP and caikit-tgis-isvc-grpc for gRPC)

--- a/demo/kserve/custom-manifests/caikit/caikit-tgis/caikit-tgis-isvc-grpc.yaml
+++ b/demo/kserve/custom-manifests/caikit/caikit-tgis/caikit-tgis-isvc-grpc.yaml
@@ -5,8 +5,6 @@ metadata:
     serving.knative.openshift.io/enablePassthrough: "true"
     sidecar.istio.io/inject: "true"
     sidecar.istio.io/rewriteAppHTTPProbers: "true"
-  labels:
-    protocol: "grpconly" # workaround for https://issues.redhat.com/browse/RHOAIENG-165
   name: caikit-tgis-isvc-grpc
 spec:
   predictor:

--- a/demo/kserve/custom-manifests/tgis/tgis-isvc-grpc-template.yaml
+++ b/demo/kserve/custom-manifests/tgis/tgis-isvc-grpc-template.yaml
@@ -5,8 +5,6 @@ metadata:
     serving.knative.openshift.io/enablePassthrough: "true"
     sidecar.istio.io/inject: "true"
     sidecar.istio.io/rewriteAppHTTPProbers: "true"
-  labels:
-    protocol: "grpconly" # workaround for https://issues.redhat.com/browse/RHOAIENG-165
   # The following <tgis-isvc-name> should be set to the
   # actual name of the inference service. (e.g., tgis-grpc-isvc)
   name: <tgis-grpc-isvc-name>

--- a/demo/kserve/custom-manifests/tgis/tgis-isvc-grpc.yaml
+++ b/demo/kserve/custom-manifests/tgis/tgis-isvc-grpc.yaml
@@ -5,8 +5,6 @@ metadata:
     serving.knative.openshift.io/enablePassthrough: "true"
     sidecar.istio.io/inject: "true"
     sidecar.istio.io/rewriteAppHTTPProbers: "true"
-  labels:
-    protocol: "grpconly" # workaround for https://issues.redhat.com/browse/RHOAIENG-165
   name: tgis-example-isvc-grpc
 spec:
   predictor:


### PR DESCRIPTION
was temporary fix for [RHOAIENG-165](https://issues.redhat.com//browse/RHOAIENG-165)
