### PR TITLE
manifests: add initialDelaySeconds field

### DIFF
--- a/demo/kserve/custom-manifests/caikit/caikit-standalone/caikit-standalone-servingruntime-grpc.yaml
+++ b/demo/kserve/custom-manifests/caikit/caikit-standalone/caikit-standalone-servingruntime-grpc.yaml
@@ -36,6 +36,7 @@ spec:
             - -m
             - caikit_health_probe
             - readiness
+        initialDelaySeconds: 5 # might require larger values for large models
       livenessProbe:
         exec:
           command:
@@ -43,3 +44,4 @@ spec:
             - -m
             - caikit_health_probe
             - liveness
+        initialDelaySeconds: 5

--- a/demo/kserve/custom-manifests/caikit/caikit-standalone/caikit-standalone-servingruntime.yaml
+++ b/demo/kserve/custom-manifests/caikit/caikit-standalone/caikit-standalone-servingruntime.yaml
@@ -35,6 +35,7 @@ spec:
             - -m
             - caikit_health_probe
             - readiness
+        initialDelaySeconds: 5 # might require larger values for large models
       livenessProbe:
         exec:
           command:
@@ -42,3 +43,4 @@ spec:
             - -m
             - caikit_health_probe
             - liveness
+        initialDelaySeconds: 5

--- a/demo/kserve/custom-manifests/caikit/caikit-tgis/caikit-tgis-servingruntime-grpc.yaml
+++ b/demo/kserve/custom-manifests/caikit/caikit-tgis/caikit-tgis-servingruntime-grpc.yaml
@@ -44,6 +44,7 @@ spec:
             - -m
             - caikit_health_probe
             - readiness
+        initialDelaySeconds: 5 # might require larger values for large models
       livenessProbe:
         exec:
           command:
@@ -51,6 +52,7 @@ spec:
             - -m
             - caikit_health_probe
             - liveness
+        initialDelaySeconds: 5
       # resources: # configure as required
       #   requests:
       #     cpu: 8

--- a/demo/kserve/custom-manifests/caikit/caikit-tgis/caikit-tgis-servingruntime-template.yaml
+++ b/demo/kserve/custom-manifests/caikit/caikit-tgis/caikit-tgis-servingruntime-template.yaml
@@ -61,6 +61,8 @@ objects:
                 - -m
                 - caikit_health_probe
                 - readiness
+            initialDelaySeconds: ${PROBES_INITIAL_DELAY_SECONDS}
+
           livenessProbe:
             exec:
               command:
@@ -68,6 +70,8 @@ objects:
                 - -m
                 - caikit_health_probe
                 - liveness
+            initialDelaySeconds: ${PROBES_INITIAL_DELAY_SECONDS}
+
 parameters:
   - name: CPU_REQUEST
     description: CPU request for the container
@@ -81,3 +85,6 @@ parameters:
   - name: TGIS_CONTAINER_IMAGE
     description: Container image for the runtime
     value: quay.io/opendatahub/text-generation-inference:stable
+  - name: PROBES_INITIAL_DELAY_SECONDS
+    description: Time to wait before performing initial probes. Useful when loading large models.
+    value: 5

--- a/demo/kserve/custom-manifests/caikit/caikit-tgis/caikit-tgis-servingruntime.yaml
+++ b/demo/kserve/custom-manifests/caikit/caikit-tgis/caikit-tgis-servingruntime.yaml
@@ -43,6 +43,7 @@ spec:
             - -m
             - caikit_health_probe
             - readiness
+        initialDelaySeconds: 5 # might require larger values for large models
       livenessProbe:
         exec:
           command:
@@ -50,6 +51,7 @@ spec:
             - -m
             - caikit_health_probe
             - liveness
+        initialDelaySeconds: 5
       # resources: # configure as required
       #   requests:
       #     cpu: 8

--- a/demo/kserve/custom-manifests/tgis/tgis-servingruntime-template.yaml
+++ b/demo/kserve/custom-manifests/tgis/tgis-servingruntime-template.yaml
@@ -45,13 +45,13 @@ objects:
               command:
                 - curl
                 - localhost:3000/health
-            initialDelaySeconds: 5
+            initialDelaySeconds: ${PROBES_INITIAL_DELAY_SECONDS}
           livenessProbe:
             exec:
               command:
                 - curl
                 - localhost:3000/health
-            initialDelaySeconds: 5
+            initialDelaySeconds: ${PROBES_INITIAL_DELAY_SECONDS}
           ports:
             - containerPort: 8033
               name: h2c
@@ -66,3 +66,6 @@ parameters:
   - name: TGIS_CONTAINER_IMAGE
     description: Container image for the runtime
     value: quay.io/opendatahub/text-generation-inference:stable
+  - name: PROBES_INITIAL_DELAY_SECONDS
+    description: Time to wait before performing initial probes. Useful when loading large models.
+    value: 5


### PR DESCRIPTION
As part of a solution to https://issues.redhat.com/browse/RHOAIENG-4227, this PR adds a `PROBES_INITIAL_DELAY_SECONDS` field to the ServingRuntime templates in order to allow users to specify expected loading times when deploying large models (such as LLMs)
