### PR TITLE
Add script to wait for the model to appear when using KServe Modelcar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR /caikit
 
 COPY --from=poetry-builder /caikit/.venv /caikit/.venv
 COPY caikit.yml /caikit/config/caikit.yml
+COPY --chown=1001:0 --chmod=554 utils/wait-modelcar.sh .
 
 ENV VIRTUAL_ENV=/caikit/.venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
@@ -38,4 +39,5 @@ USER caikit
 ENV CONFIG_FILES=/caikit/config/caikit.yml
 VOLUME ["/caikit/config/"]
 
+ENTRYPOINT ["/caikit/wait-modelcar.sh"]
 CMD ["python",  "-m", "caikit.runtime"]

--- a/utils/wait-modelcar.sh
+++ b/utils/wait-modelcar.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ "${MODEL_INIT_MODE}" = "async" ] ; then
+  echo "Waiting for model files (modelcar) to be present..."
+  until test -e /mnt/models; do
+    sleep 1
+  done
+
+  echo "Model files are now available."
+fi
+
+echo "Starting model server..."
+eval $@
+


### PR DESCRIPTION
When using OCI containers for model storage in KServe (modelcar), there is the possibility that the model server starts before the model has been fully downloaded. When this happens, the model server would terminate with error because the model path is empty.

This adds a small script to wait for the cluster to fully download the model container before invoking the model server. The waiting is triggered when the MODEL_INIT_MODE environment variable is set to "async".

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
