### PR TITLE
(feat): Update dockerfile to support multi-arch images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as poetry-builder
 
 RUN microdnf -y update && \
     microdnf -y install \
-        git shadow-utils python3.11-pip python-wheel && \
+        git shadow-utils python3.11-pip python-wheel \
+        gcc python3.11-devel && \
     pip3.11 install --no-cache-dir --upgrade pip wheel && \
     microdnf clean all
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In order to support multi-arch builds in konflux, we need some updates in the Dockerfile.
The issue we are trying to solve is:
caikit uses [psutil version 5](https://github.com/caikit/caikit/blob/main/pyproject.toml#L25) which doesn't have python wheel support. The support starts at https://github.com/giampaolo/psutil/issues/1782#issuecomment-2235986126. Hence building from source by installing some devel tools.

JIRA: https://issues.redhat.com/browse/RHOAIENG-28782

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment to include additional system packages for improved compatibility during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->