### PR TITLE
Upgrade urllib3 to 2.6.3 to fix CVE-2025-66418

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,11 @@ COPY caikit.yml /caikit/config/caikit.yml
 
 ENV VIRTUAL_ENV=/caikit/.venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN /caikit/.venv/bin/pip install --no-cache-dir "urllib3>=2.6.0"
+
 RUN /caikit/.venv/bin/pip install --no-cache-dir "fastapi==0.123.7" "starlette>=0.49.1,<0.51.0"
+
 RUN groupadd --system caikit --gid 1001 && \
     adduser --system --uid 1001 --gid 0 --groups caikit \
     --create-home --home-dir /caikit --shell /sbin/nologin \


### PR DESCRIPTION
Addresses : https://issues.redhat.com/browse/RHOAIENG-42048

This PR fixes CVE-2025-66418 by upgrading the transitive dependency urllib3 to version 2.6.3 in the container image. The fix ensures the runtime uses a non-vulnerable version of urllib3 and has been verified inside the built image.