### PR TITLE
Upgrade accelerate to 1.12.0 to mitigate CVE-2025-14925

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY caikit.yml /caikit/config/caikit.yml
 
 ENV VIRTUAL_ENV=/caikit/.venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN /caikit/.venv/bin/pip install --no-cache-dir --upgrade "accelerate>=1.12.0"
 RUN /caikit/.venv/bin/pip install --no-cache-dir "fastapi==0.123.7" "starlette>=0.49.1,<0.51.0"
 RUN groupadd --system caikit --gid 1001 && \
     adduser --system --uid 1001 --gid 0 --groups caikit \


### PR DESCRIPTION

This PR mitigates CVE-2025-14925 by upgrading the transitive dependency Hugging Face Accelerate to version 1.12.0 in the container image. The change ensures the runtime uses a non-vulnerable version of accelerate and has been verified inside the built image.