### PR TITLE
upgrade aiohttp to 3.13.3 to prevent zip bomb DoS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 RUN /caikit/.venv/bin/pip install --no-cache-dir "urllib3>=2.6.0"
 
-RUN /caikit/.venv/bin/pip install --no-cache-dir "fastapi==0.123.7" "starlette>=0.49.1,<0.51.0"
-
+RUN /caikit/.venv/bin/pip install --no-cache-dir \
+    "fastapi==0.123.7" "starlette>=0.49.1,<0.51.0" "aiohttp>=3.13.3,<4.0.0"
 RUN groupadd --system caikit --gid 1001 && \
     adduser --system --uid 1001 --gid 0 --groups caikit \
     --create-home --home-dir /caikit --shell /sbin/nologin \


### PR DESCRIPTION
Addresses : https://issues.redhat.com/browse/RHOAIENG-43597

This PR addresses [RHOAIENG-43597](https://issues.redhat.com//browse/RHOAIENG-43597) by fixing a denial-of-service vulnerability in the transitive dependency aiohttp. Versions ≤3.13.2 are vulnerable to a zip-bomb attack via automatic decompression, which can lead to memory exhaustion. The dependency has been pinned to aiohttp 3.13.3, which includes the upstream fix, and the lockfile has been updated to ensure the resolved version is used at runtime. The fix was verified by confirming the installed aiohttp version inside the built container.