### PR TITLE
fix: upgrade aiohttp to 3.14.0+ to address CVE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN /caikit/.venv/bin/pip install --no-cache-dir "urllib3>=2.6.0"
 
 RUN /caikit/.venv/bin/pip install --no-cache-dir \
-    "fastapi>=0.134.0" "starlette>=1.0.1" "aiohttp>=3.13.3,<4.0.0" "python-dotenv==1.2.2"
+    "fastapi>=0.134.0" "starlette>=1.0.1" "aiohttp>=3.14.0,<4.0.0" "python-dotenv==1.2.2"
 
 RUN groupadd --system caikit --gid 1001 && \
     adduser --system --uid 1001 --gid 0 --groups caikit \


### PR DESCRIPTION
Addresses : https://redhat.atlassian.net/browse/RHOAIENG-65929

Fix aiohttp arbitrary code execution vulnerability (CVE) by upgrading to version 3.14.0+
