### PR TITLE
fix: upgrade urllib3 to 2.7.0+ to address CVE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY caikit.yml /caikit/config/caikit.yml
 ENV VIRTUAL_ENV=/caikit/.venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-RUN /caikit/.venv/bin/pip install --no-cache-dir "urllib3>=2.6.0"
+RUN /caikit/.venv/bin/pip install --no-cache-dir "urllib3>=2.7.0"
 
 RUN /caikit/.venv/bin/pip install --no-cache-dir \
     "fastapi>=0.134.0" "starlette>=1.0.1" "aiohttp>=3.14.0,<4.0.0" "python-dotenv==1.2.2"


### PR DESCRIPTION
fix: upgrade urllib3 to 2.7.0+ to address CVE

Upgrade urllib3 from >=2.6.0 to >=2.7.0 to fix information disclosure vulnerability via cross-origin redirects forwarding sensitive headers.

Addresses : https://redhat.atlassian.net/browse/RHOAIENG-64457