### PR TITLE
fix: upgrade ujson to 5.12.1+ to address CVE memory leak

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN /caikit/.venv/bin/pip install --no-cache-dir "urllib3>=2.7.0"
 
 RUN /caikit/.venv/bin/pip install --no-cache-dir \
-    "fastapi>=0.134.0" "starlette>=1.0.1" "aiohttp>=3.14.0,<4.0.0" "python-dotenv==1.2.2"
+    "fastapi>=0.134.0" "starlette>=1.0.1" "aiohttp>=3.14.0,<4.0.0" "python-dotenv==1.2.2" "ujson>=5.12.1"
 
 RUN groupadd --system caikit --gid 1001 && \
     adduser --system --uid 1001 --gid 0 --groups caikit \


### PR DESCRIPTION
Addresses : https://redhat.atlassian.net/browse/RHOAIENG-67369

  ## Summary
  - Upgrades ujson from 5.10.0 to >=5.12.1
  - Fixes memory leak DoS vulnerability in ujson.dump()
  - Follows existing CVE mitigation pattern (urllib3/fastapi/aiohttp)
