### PR TITLE
fix: upgrade aiohttp to 3.14.3+ to address CVE-2026-69244

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN /caikit/.venv/bin/pip install --no-cache-dir "urllib3>=2.7.0"
 
 RUN /caikit/.venv/bin/pip install --no-cache-dir \
-    "fastapi>=0.134.0" "starlette>=1.3.1" "aiohttp>=3.14.0,<4.0.0" "python-dotenv==1.2.2" "ujson>=5.12.1"
+    "fastapi>=0.134.0" "starlette>=1.3.1" "aiohttp>=3.14.3,<4.0.0" "python-dotenv==1.2.2" "ujson>=5.12.1"
 
 RUN groupadd --system caikit --gid 1001 && \
     adduser --system --uid 1001 --gid 0 --groups caikit \


### PR DESCRIPTION
## Summary
- Bumps aiohttp pip override from `>=3.14.0` to `>=3.14.3` in `Dockerfile`
- Addresses **CVE-2026-69244**: AIOHTTP Denial of Service via malformed HTTP responses — out-of-bounds heap read in the C response parser during error message construction for malformed chunked responses
- Fixed upstream in aiohttp 3.14.3

## Test plan
- [ ] Verify image builds successfully with aiohttp 3.14.3
- [ ] Confirm no runtime regressions in caikit serving